### PR TITLE
gateware/midi: add a simple midi library and `midicv` example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,3 +49,20 @@ jobs:
           pdm install
           pdm sim_dsp_core nco
         working-directory: gateware
+
+  ubuntu-bitstream-dsp-midicv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pdm-project/setup-pdm@v3
+      - uses: YosysHQ/setup-oss-cad-suite@v3
+      - run: git submodule update --init --recursive
+      - run: yosys --version
+      - run: |
+          pdm install
+          pdm build_dsp_core midicv
+        working-directory: gateware
+      - uses: actions/upload-artifact@v3
+        with:
+          name: example-dsp-midicv.bit
+          path: gateware/build/top.bit

--- a/gateware/src/example_dsp/sim_dsp_core.cpp
+++ b/gateware/src/example_dsp/sim_dsp_core.cpp
@@ -1,3 +1,10 @@
+// Copyright (c) 2024 S. Holzapfel, apfelaudio UG <info@apfelaudio.com>
+//
+// SPDX-License-Identifier: CERN-OHL-S-2.0
+//
+
+// Simple verilator wrapper for simulating self-contained Tiliqua DSP core.
+
 #if defined VM_TRACE_FST && VM_TRACE_FST == 1
 #include <verilated_fst_c.h>
 #endif

--- a/gateware/src/example_dsp/top.py
+++ b/gateware/src/example_dsp/top.py
@@ -433,44 +433,81 @@ class QuadNCO(wiring.Component):
 
 class MidiCVTop(wiring.Component):
 
-    """Convert serial MIDI messages to CV voltages."""
+    """
+    Simple monophonic MIDI to CV conversion.
 
-    # TODO: this core is in progress
+    Output mapping is:
+    Output 0: Gate
+    Output 1: V/oct CV
+    Output 2: Velocity
+    Output 3: Mod Wheel (CC1)
+    """
 
     i: In(stream.Signature(data.ArrayLayout(ASQ, 4)))
     o: Out(stream.Signature(data.ArrayLayout(ASQ, 4)))
 
+    # Note: MIDI is valid at a much lower rate than audio streams
     i_midi: In(stream.Signature(midi.MidiMessage))
 
     def elaborate(self, platform):
         m = Module()
 
         m.d.comb += [
+            # Always forward our audio payload
             self.i.ready.eq(1),
             self.o.valid.eq(1),
+
+            # Always ready for MIDI messages
             self.i_midi.ready.eq(1),
         ]
+
+        # Create a LUT from midi note to voltage (output ASQ).
+        lut = []
+        for i in range(128):
+            volts_per_note = 1.0/12.0
+            volts = i*volts_per_note - 5
+            # convert volts to audio sample
+            x = volts/(2**15/4000)
+            lut.append(fixed.Const(x, shape=ASQ)._value)
+
+        # Store it in a memory where the address is the midi note,
+        # and the data coming out is directly routed to V/Oct out.
+        m.submodules.mem = mem = Memory(
+            width=ASQ.as_shape().width, depth=len(lut), init=lut)
+        rport = mem.read_port(transparent=True)
+        m.d.comb += [
+            rport.en.eq(1),
+        ]
+
+        # Route memory straight out to our note payload.
+        m.d.sync += self.o.payload[1].as_value().eq(rport.data),
 
         with m.If(self.i_midi.valid):
             msg = self.i_midi.payload
             with m.Switch(msg.midi_type):
                 with m.Case(midi.MessageType.NOTE_ON):
                     m.d.sync += [
-                        self.o.payload[0].eq(fixed.Const(0.25, shape=ASQ)),
-                        self.o.payload[1].as_value().eq(
-                            msg.midi_payload.note_on.note << 8),
+                        # Gate output on
+                        self.o.payload[0].eq(fixed.Const(0.5, shape=ASQ)),
+                        # Set velocity output
                         self.o.payload[2].as_value().eq(
                             msg.midi_payload.note_on.velocity << 8),
+                        # Set note index in LUT
+                        rport.addr.eq(msg.midi_payload.note_on.note),
                     ]
                 with m.Case(midi.MessageType.NOTE_OFF):
+                    # Zero gate and velocity on NOTE_OFF
                     m.d.sync += [
-                        self.o.payload[0].eq(fixed.Const(0.0, shape=ASQ))
+                        self.o.payload[0].eq(0),
+                        self.o.payload[2].eq(0),
                     ]
-                with m.Case(midi.MessageType.PITCH_BEND):
-                    m.d.sync += [
-                        self.o.payload[3].as_value().eq(
-                            msg.midi_payload.pitch_bend.msb << 8),
-                    ]
+                with m.Case(midi.MessageType.CONTROL_CHANGE):
+                    # mod wheel is CC 1
+                    with m.If(msg.midi_payload.control_change.controller_number == 1):
+                        m.d.sync += [
+                            self.o.payload[3].as_value().eq(
+                                msg.midi_payload.control_change.data << 8),
+                        ]
 
         return m
 

--- a/gateware/src/tiliqua/dsp.py
+++ b/gateware/src/tiliqua/dsp.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2024 S. Holzapfel, apfelaudio UG <info@apfelaudio.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Streaming DSP library with a strong focus on audio."""
+
 from amaranth              import *
 from amaranth.lib          import wiring, data
 from amaranth.lib.wiring   import In, Out

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -1,6 +1,9 @@
-# Copyright (c) 2024 Seb Holzapfel <me@sebholzapfel.com>
+# Copyright (c) 2024 S. Holzapfel, apfelaudio UG <info@apfelaudio.com>
 #
-# SPDX-License-Identifier: BSD--3-Clause
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Amaranth wrapper and clock domain crossing for `eurorack-pmod` hardware."""
 
 import os
 

--- a/gateware/src/tiliqua/midi.py
+++ b/gateware/src/tiliqua/midi.py
@@ -1,0 +1,125 @@
+# Helpers for dealing with MIDI over serial or USB.
+
+from amaranth import *
+from amaranth.lib.fifo import SyncFIFOBuffered
+from amaranth.lib          import wiring, data, enum
+from amaranth.lib.wiring   import In, Out
+
+from amaranth_future import stream
+from vendor.serial import AsyncSerialRX
+
+MIDI_BAUD_RATE = 31250
+
+class MessageType(enum.Enum, shape=unsigned(4)):
+    NOTE_OFF         = 0x8
+    NOTE_ON          = 0x9
+    POLY_PRESSURE    = 0xA
+    CONTROL_CHANGE   = 0xB
+    PROGRAM_CHANGE   = 0xC
+    CHANNEL_PRESSURE = 0xD
+    PITCH_BEND       = 0xE
+    SYSEX            = 0xF
+
+class MidiMessage(data.Struct):
+    midi_type:    MessageType # 4 bit message type
+    midi_channel: unsigned(4) # 4 bit midi channel
+    midi_payload: data.UnionLayout({
+        "note_off": data.StructLayout({
+            "note": unsigned(8),
+            "velocity": unsigned(8)
+        }),
+        "note_on": data.StructLayout({
+            "note": unsigned(8),
+            "velocity": unsigned(8)
+        }),
+        "poly_pressure": data.StructLayout({
+            "note": unsigned(8),
+            "pressure": unsigned(8)
+        }),
+        "control_change": data.StructLayout({
+            "controller_number": unsigned(8),
+            "data": unsigned(8)
+        }),
+        "program_change": data.StructLayout({
+            "program_number": unsigned(8),
+            "_unused": unsigned(8)
+        }),
+        "channel_pressure": data.StructLayout({
+            "pressure": unsigned(8),
+            "_unused": unsigned(8)
+        }),
+        "pitch_bend": data.StructLayout({
+            "lsb": unsigned(8),
+            "msb": unsigned(8)
+        }),
+    })
+
+class SerialRx(wiring.Component):
+
+    """Stream of raw bytes from a serial port at MIDI baud rates."""
+
+    o: Out(stream.Signature(unsigned(8)))
+
+    def __init__(self, *, system_clk_hz, pins, rx_depth=64):
+
+        self.phy = AsyncSerialRX(
+            divisor=int(system_clk_hz // MIDI_BAUD_RATE),
+            pins=pins)
+        self.rx_fifo = SyncFIFOBuffered(
+            width=self.phy.data.width, depth=rx_depth)
+
+        super().__init__()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules._phy = self.phy
+        m.submodules._rx_fifo = self.rx_fifo
+
+        # serial PHY -> RX FIFO
+        m.d.comb += [
+            self.rx_fifo.w_data.eq(self.phy.data),
+            self.rx_fifo.w_en.eq(self.phy.rdy),
+            self.phy.ack.eq(self.rx_fifo.w_rdy),
+        ]
+
+        # RX FIFO -> output stream
+        rstream = stream.fifo_r_stream(self.rx_fifo)
+        wiring.connect(m, rstream, wiring.flipped(self.o))
+
+        return m
+
+class MidiDecode(wiring.Component):
+
+    """Convert raw MIDI bytes into a stream of MIDI messages."""
+
+    i: In(stream.Signature(unsigned(8)))
+    o: Out(stream.Signature(MidiMessage))
+
+    def elaborate(self, platform):
+        m = Module()
+
+        with m.FSM() as fsm:
+            with m.State('WAIT-VALID'):
+                m.d.comb += self.i.ready.eq(1),
+                # all valid command messages have highest bit set
+                with m.If(self.i.valid & (self.i.payload & 0x80)):
+                    m.d.sync += self.o.payload.as_value()[:8].eq(self.i.payload)
+                    m.next = 'READ0'
+                    # skip anything that looks suspicious
+            with m.State('READ0'):
+                m.d.comb += self.i.ready.eq(1),
+                with m.If(self.i.valid):
+                    m.d.sync += self.o.payload.as_value()[8:16].eq(self.i.payload)
+                    m.next = 'READ1'
+            with m.State('READ1'):
+                m.d.comb += self.i.ready.eq(1),
+                with m.If(self.i.valid):
+                    m.d.sync += self.o.payload.as_value()[16:24].eq(self.i.payload)
+                    m.next = 'WAIT-READY'
+            with m.State('WAIT-READY'):
+                m.d.comb += self.o.valid.eq(1),
+                with m.If(self.o.ready):
+                    m.next = 'WAIT-VALID'
+
+        return m

--- a/gateware/src/tiliqua/midi.py
+++ b/gateware/src/tiliqua/midi.py
@@ -1,4 +1,9 @@
-# Helpers for dealing with MIDI over serial or USB.
+# Copyright (c) 2024 S. Holzapfel, apfelaudio UG <info@apfelaudio.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Helpers for dealing with MIDI over serial or USB."""
 
 from amaranth import *
 from amaranth.lib.fifo import SyncFIFOBuffered

--- a/gateware/src/tiliqua/sim.py
+++ b/gateware/src/tiliqua/sim.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2024 S. Holzapfel, apfelaudio UG <info@apfelaudio.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+#
+
+"""Utilities for simulating Tiliqua designs."""
+
 from amaranth              import *
 from amaranth.build        import *
 from amaranth.lib          import wiring, data

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -44,7 +44,7 @@ class _TiliquaPlatform(LatticeECP5Platform):
         # MIDI I/O
         UARTResource(1,
             rx="D5", tx="B8",
-            attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="UP")
+            attrs=Attrs(IO_TYPE="LVCMOS33", PULLMODE="NONE")
         ),
 
         # USB

--- a/gateware/src/vendor/serial.py
+++ b/gateware/src/vendor/serial.py
@@ -1,0 +1,275 @@
+# from https://github.com/amaranth-lang/amaranth-stdio
+# license: 2-clause BSD
+
+from amaranth import *
+from amaranth.lib.cdc import FFSynchronizer
+from amaranth.utils import bits_for
+
+
+__all__ = ["AsyncSerialRX", "AsyncSerialTX", "AsyncSerial"]
+
+
+def _check_divisor(divisor, bound):
+    if divisor < bound:
+        raise ValueError("Invalid divisor {!r}; must be greater than or equal to {}"
+                         .format(divisor, bound))
+
+
+def _check_parity(parity):
+    choices = ("none", "mark", "space", "even", "odd")
+    if parity not in choices:
+        raise ValueError("Invalid parity {!r}; must be one of {}"
+                         .format(parity, ", ".join(choices)))
+
+
+def _compute_parity_bit(data, parity):
+    if parity == "none":
+        return C(0, 0)
+    if parity == "mark":
+        return C(1, 1)
+    if parity == "space":
+        return C(0, 1)
+    if parity == "even":
+        return data.xor()
+    if parity == "odd":
+        return ~data.xor()
+    assert False
+
+
+def _wire_layout(data_bits, parity="none"):
+    return [
+        ("start",  1),
+        ("data",   data_bits),
+        ("parity", 0 if parity == "none" else 1),
+        ("stop",   1),
+    ]
+
+
+class AsyncSerialRX(Elaboratable):
+    """Asynchronous serial receiver.
+
+    Parameters
+    ----------
+    divisor : int
+        Clock divisor reset value. Should be set to ``int(clk_frequency // baudrate)``.
+    divisor_bits : int
+        Optional. Clock divisor width. If omitted, ``bits_for(divisor)`` is used instead.
+    data_bits : int
+        Data width.
+    parity : ``"none"``, ``"mark"``, ``"space"``, ``"even"``, ``"odd"``
+        Parity mode.
+    pins : :class:`amaranth.lib.io.Pin`
+        Optional. UART pins. See :class:`amaranth_boards.resources.UARTResource` for layout.
+
+    Attributes
+    ----------
+    divisor : Signal, in
+        Clock divisor.
+    data : Signal, out
+        Read data. Valid only when ``rdy`` is asserted.
+    err.overflow : Signal, out
+        Error flag. A new frame has been received, but the previous one was not acknowledged.
+    err.frame : Signal, out
+        Error flag. The received bits do not fit in a frame.
+    err.parity : Signal, out
+        Error flag. The parity check has failed.
+    rdy : Signal, out
+        Read strobe.
+    ack : Signal, in
+        Read acknowledge. Must be held asserted while data can be read out of the receiver.
+    i : Signal, in
+        Serial input. If ``pins`` has been specified, ``pins.rx.i`` drives it.
+    """
+    def __init__(self, *, divisor, divisor_bits=None, data_bits=8, parity="none", pins=None):
+        _check_parity(parity)
+        self._parity = parity
+
+        # The clock divisor must be at least 5 to keep the FSM synchronized with the serial input
+        # during a DONE->IDLE->BUSY transition.
+        _check_divisor(divisor, 5)
+        self.divisor = Signal(divisor_bits or bits_for(divisor), reset=divisor)
+
+        self.data = Signal(data_bits)
+        self.err  = Record([
+            ("overflow", 1),
+            ("frame",    1),
+            ("parity",   1),
+        ])
+        self.rdy  = Signal()
+        self.ack  = Signal()
+
+        self.i    = Signal(reset=1)
+
+        self._pins = pins
+
+    def elaborate(self, platform):
+        m = Module()
+
+        timer = Signal.like(self.divisor)
+        shreg = Record(_wire_layout(len(self.data), self._parity))
+        bitno = Signal(range(len(shreg)))
+
+        if self._pins is not None:
+            m.submodules += FFSynchronizer(self._pins.rx.i, self.i, reset=1)
+
+        with m.FSM() as fsm:
+            with m.State("IDLE"):
+                with m.If(~self.i):
+                    m.d.sync += [
+                        bitno.eq(len(shreg) - 1),
+                        timer.eq(self.divisor >> 1),
+                    ]
+                    m.next = "BUSY"
+
+            with m.State("BUSY"):
+                with m.If(timer != 0):
+                    m.d.sync += timer.eq(timer - 1)
+                with m.Else():
+                    m.d.sync += [
+                        shreg.eq(Cat(shreg[1:], self.i)),
+                        bitno.eq(bitno - 1),
+                        timer.eq(self.divisor - 1),
+                    ]
+                    with m.If(bitno == 0):
+                        m.next = "DONE"
+
+            with m.State("DONE"):
+                with m.If(self.ack):
+                    m.d.sync += [
+                        self.data.eq(shreg.data),
+                        self.err.frame .eq(~((shreg.start == 0) & (shreg.stop == 1))),
+                        self.err.parity.eq(~(shreg.parity ==
+                                             _compute_parity_bit(shreg.data, self._parity))),
+                    ]
+                m.d.sync += self.err.overflow.eq(~self.ack)
+                m.next = "IDLE"
+
+        with m.If(self.ack):
+            m.d.sync += self.rdy.eq(fsm.ongoing("DONE"))
+
+        return m
+
+
+class AsyncSerialTX(Elaboratable):
+    """Asynchronous serial transmitter.
+
+    Parameters
+    ----------
+    divisor : int
+        Clock divisor reset value. Should be set to ``int(clk_frequency // baudrate)``.
+    divisor_bits : int
+        Optional. Clock divisor width. If omitted, ``bits_for(divisor)`` is used instead.
+    data_bits : int
+        Data width.
+    parity : ``"none"``, ``"mark"``, ``"space"``, ``"even"``, ``"odd"``
+        Parity mode.
+    pins : :class:`amaranth.lib.io.Pin`
+        Optional. UART pins. See :class:`amaranth_boards.resources.UARTResource` for layout.
+
+    Attributes
+    ----------
+    divisor : Signal, in
+        Clock divisor.
+    data : Signal, in
+        Write data. Valid only when ``ack`` is asserted.
+    rdy : Signal, out
+        Write ready. Asserted when the transmitter is ready to transmit data.
+    ack : Signal, in
+        Write strobe. Data gets transmitted when both ``rdy`` and ``ack`` are asserted.
+    o : Signal, out
+        Serial output. If ``pins`` has been specified, it drives ``pins.tx.o``.
+    """
+    def __init__(self, *, divisor, divisor_bits=None, data_bits=8, parity="none", pins=None):
+        _check_parity(parity)
+        self._parity = parity
+
+        _check_divisor(divisor, 1)
+        self.divisor = Signal(divisor_bits or bits_for(divisor), reset=divisor)
+
+        self.data = Signal(data_bits)
+        self.rdy  = Signal()
+        self.ack  = Signal()
+
+        self.o    = Signal(reset=1)
+
+        self._pins = pins
+
+    def elaborate(self, platform):
+        m = Module()
+
+        timer = Signal.like(self.divisor)
+        shreg = Record(_wire_layout(len(self.data), self._parity))
+        bitno = Signal(range(len(shreg)))
+
+        if self._pins is not None:
+            m.d.comb += self._pins.tx.o.eq(self.o)
+
+        with m.FSM():
+            with m.State("IDLE"):
+                m.d.comb += self.rdy.eq(1)
+                with m.If(self.ack):
+                    m.d.sync += [
+                        shreg.start .eq(0),
+                        shreg.data  .eq(self.data),
+                        shreg.parity.eq(_compute_parity_bit(self.data, self._parity)),
+                        shreg.stop  .eq(1),
+                        bitno.eq(len(shreg) - 1),
+                        timer.eq(self.divisor - 1),
+                    ]
+                    m.next = "BUSY"
+
+            with m.State("BUSY"):
+                with m.If(timer != 0):
+                    m.d.sync += timer.eq(timer - 1)
+                with m.Else():
+                    m.d.sync += [
+                        Cat(self.o, shreg).eq(shreg),
+                        bitno.eq(bitno - 1),
+                        timer.eq(self.divisor - 1),
+                    ]
+                    with m.If(bitno == 0):
+                        m.next = "IDLE"
+
+        return m
+
+
+class AsyncSerial(Elaboratable):
+    """Asynchronous serial transceiver.
+
+    Parameters
+    ----------
+    divisor : int
+        Clock divisor reset value. Should be set to ``int(clk_frequency // baudrate)``.
+    divisor_bits : int
+        Optional. Clock divisor width. If omitted, ``bits_for(divisor)`` is used instead.
+    data_bits : int
+        Data width.
+    parity : ``"none"``, ``"mark"``, ``"space"``, ``"even"``, ``"odd"``
+        Parity mode.
+    pins : :class:`amaranth.lib.io.Pin`
+        Optional. UART pins. See :class:`amaranth_boards.resources.UARTResource` for layout.
+
+    Attributes
+    ----------
+    divisor : Signal, in
+        Clock divisor.
+    rx : :class:`AsyncSerialRX`
+        See :class:`AsyncSerialRX`.
+    tx : :class:`AsyncSerialTX`
+        See :class:`AsyncSerialTX`.
+    """
+    def __init__(self, *, divisor, divisor_bits=None, **kwargs):
+        self.divisor = Signal(divisor_bits or bits_for(divisor), reset=divisor)
+
+        self.rx = AsyncSerialRX(divisor=divisor, divisor_bits=divisor_bits, **kwargs)
+        self.tx = AsyncSerialTX(divisor=divisor, divisor_bits=divisor_bits, **kwargs)
+
+    def elaborate(self, platform):
+        m = Module()
+        m.submodules.rx = self.rx
+        m.submodules.tx = self.tx
+        m.d.comb += [
+            self.rx.divisor.eq(self.divisor),
+            self.tx.divisor.eq(self.divisor),
+        ]
+        return m


### PR DESCRIPTION
* implement a simple library for decoding binary midi streams
* add an example bitstream that converts serial midi into CV signals on the tiliqua outputs