### PR TITLE
gateware/i2c: implement i2c peripheral, integrate in `example_soc`

### DIFF
--- a/gateware/src/example_soc/fw/Cargo.lock
+++ b/gateware/src/example_soc/fw/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
 name = "tiliqua-fw"
 version = "0.1.0"
 dependencies = [
+ "embedded-hal 1.0.0-alpha.9",
  "log",
  "lunasoc-hal",
  "panic-halt",

--- a/gateware/src/example_soc/fw/Cargo.toml
+++ b/gateware/src/example_soc/fw/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+embedded-hal = "=1.0.0-alpha.9"
 riscv = { version = "=0.10.1", features = ["critical-section-single-hart"] }
 riscv-rt = { version = "=0.11.0" }
 panic-halt = "0.2.0"
-
 tiliqua-pac = { path="../pac", default-features = false, features = ["critical-section", "vexriscv"] }
 lunasoc-hal = { git = "https://github.com/greatscottgadgets/cynthion.git", default-features = false, features = ["vexriscv"]}
 

--- a/gateware/src/example_soc/fw/src/i2c.rs
+++ b/gateware/src/example_soc/fw/src/i2c.rs
@@ -1,0 +1,66 @@
+use embedded_hal::i2c::{Operation, ErrorKind};
+
+use tiliqua_pac as pac;
+
+pub struct I2cDevice {
+    inner: pac::I2C0,
+}
+
+/// TODO: switch to embedded-hal proper once luna-soc is no longer
+/// pinned to a version of embedded-hal pre-1.0.0 that doesn't have
+/// the I2C transaction API yet.
+///
+impl I2cDevice {
+
+    pub fn new(dev: pac::I2C0) -> Self {
+        I2cDevice {
+            inner: dev
+        }
+    }
+
+    pub fn transaction(
+        &mut self,
+        address: u8,
+        operations: &mut [Operation<'_>],
+    ) -> Result<(), ErrorKind> {
+
+        self.inner.address().write(|w| unsafe { w.address().bits(address) } );
+        for op in operations.iter() {
+            match op {
+                Operation::Write(bytes) => {
+                    for b in bytes.iter() {
+                        self.inner.transaction_data().write(
+                            |w| unsafe { w.transaction_data().bits(0x0000u16 | *b as u16) } );
+                    }
+                }
+                Operation::Read(bytes) => {
+                    for b in bytes.iter() {
+                        self.inner.transaction_data().write(
+                            |w| unsafe { w.transaction_data().bits(0x0100u16 | *b as u16) } );
+                    }
+                },
+            }
+        }
+
+        // Start executing transactions
+        self.inner.start().write(|w| w.start().bit(true) );
+
+        // Wait for completion
+        while self.inner.busy().read().busy().bit() { }
+
+        // Copy out recieved bytes
+        for op in operations.iter_mut() {
+            match op {
+                Operation::Read(bytes) => {
+                    for b in bytes.iter_mut() {
+                        *b = self.inner.rx_data().read().bits() as u8;
+                    }
+                },
+                _ => {}
+            }
+        }
+
+
+        Ok(())
+    }
+}

--- a/gateware/src/example_soc/fw/src/lib.rs
+++ b/gateware/src/example_soc/fw/src/lib.rs
@@ -13,3 +13,4 @@ lunasoc_hal::impl_timer! {
 }
 
 pub mod log;
+pub mod i2c;

--- a/gateware/src/example_soc/fw/src/main.rs
+++ b/gateware/src/example_soc/fw/src/main.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
     let mut timer = Timer0::new(peripherals.TIMER, pac::clock::sysclk());
     let mut counter = 0;
     let mut direction = true;
-    let mut led_state = 0b110000;
+    let mut led_state = 0xc000u16;
 
     info!("Peripherals initialized.");
 
@@ -108,22 +108,22 @@ fn main() -> ! {
            0x80u8, // Auto-increment starting from MODE1
            0x81u8, // MODE1
            0x01u8, // MODE2
-           0x10u8, // PWM0
-           0x10u8, // PWM1
-           0x10u8, // PWM2
-           0x10u8, // PWM3
-           0x10u8, // PWM4
-           0x10u8, // PWM5
-           0x10u8, // PWM6
-           0x10u8, // PWM7
-           0x10u8, // PWM8
-           0x10u8, // PWM9
-           0x10u8, // PWM10
-           0x10u8, // PWM11
-           0x10u8, // PWM12
-           0x10u8, // PWM13
-           0x10u8, // PWM14
-           0x10u8, // PWM15
+           (led_state >>  0) as u8, // PWM0
+           (led_state >>  1) as u8, // PWM1
+           (led_state >>  2) as u8, // PWM2
+           (led_state >>  3) as u8, // PWM3
+           (led_state >>  4) as u8, // PWM4
+           (led_state >>  5) as u8, // PWM5
+           (led_state >>  6) as u8, // PWM6
+           (led_state >>  7) as u8, // PWM7
+           (led_state >>  8) as u8, // PWM8
+           (led_state >>  9) as u8, // PWM9
+           (led_state >> 10) as u8, // PWM10
+           (led_state >> 11) as u8, // PWM11
+           (led_state >> 12) as u8, // PWM12
+           (led_state >> 13) as u8, // PWM13
+           (led_state >> 14) as u8, // PWM14
+           (led_state >> 15) as u8, // PWM15
            0xFFu8, // GRPPWM
            0x00u8, // GRPFREQ
            0xAAu8, // LEDOUT0
@@ -150,19 +150,19 @@ fn main() -> ! {
 
         if direction {
             led_state >>= 1;
-            if led_state == 0b000011 {
+            if led_state == 0x0003 {
                 direction = false;
                 info!("left: {}", counter);
             }
         } else {
             led_state <<= 1;
-            if led_state == 0b110000 {
+            if led_state == 0xc000 {
                 direction = true;
                 info!("right: {}", counter);
             }
         }
 
-        leds.output().write(|w| unsafe { w.output().bits(led_state) });
+        //leds.output().write(|w| unsafe { w.output().bits(led_state) });
         counter += 1;
     }
 }

--- a/gateware/src/example_soc/fw/src/main.rs
+++ b/gateware/src/example_soc/fw/src/main.rs
@@ -132,6 +132,8 @@ fn main() -> ! {
            0xAAu8, // LEDOUT3
         ];
 
+        // write to the LED expander
+
         i2c0.address().write(|w| unsafe { w.address().bits(0x5) } );
 
         for b in bytes {
@@ -147,6 +149,28 @@ fn main() -> ! {
         }
 
         timer.delay_ms(100).unwrap();
+
+        // read mfg ID from EEPROM
+
+        i2c0.address().write(|w| unsafe { w.address().bits(0x52) } );
+
+        i2c0.transaction_data().write(
+            |w| unsafe { w.transaction_data().bits(0x00FAu16) } );
+
+        i2c0.transaction_data().write(
+            |w| unsafe { w.transaction_data().bits(0x0100u16) } );
+
+        i2c0.transaction_data().write(
+            |w| unsafe { w.transaction_data().bits(0x0100u16) } );
+
+        i2c0.start().write(|w| unsafe { w.start().bit(true) } );
+
+        while i2c0.busy().read().busy().bit() {
+            timer.delay_ms(1).unwrap();
+        }
+
+        info!("byte0: {}", i2c0.rx_data().read().bits());
+        info!("byte1: {}", i2c0.rx_data().read().bits());
 
         if direction {
             led_state >>= 1;

--- a/gateware/src/example_soc/top.py
+++ b/gateware/src/example_soc/top.py
@@ -91,6 +91,17 @@ class HelloSoc(Elaboratable):
         if hasattr(uart_io.tx, 'oe'):
             m.d.comb += uart_io.tx.oe.eq(~self.soc.uart._phy.tx.rdy),
 
+        ep = platform.request("audio_ffc", 0)
+        m.d.comb += [
+            ep.pdn.eq(1),
+            ep.i2c_sda.o.eq(self.i2c_pins.sda.o),
+            ep.i2c_sda.oe.eq(self.i2c_pins.sda.oe),
+            self.i2c_pins.sda.i.eq(ep.i2c_sda.i),
+            ep.i2c_scl.o.eq(self.i2c_pins.scl.o),
+            ep.i2c_scl.oe.eq(self.i2c_pins.scl.oe),
+            self.i2c_pins.scl.i.eq(ep.i2c_scl.i),
+        ]
+
         return m
 
 if __name__ == "__main__":

--- a/gateware/src/example_soc/top.py
+++ b/gateware/src/example_soc/top.py
@@ -20,6 +20,8 @@ from luna_soc.util.readbin                       import get_mem_data
 from tiliqua.tiliqua_platform                    import TiliquaPlatform
 from tiliqua.psram_peripheral                    import PSRAMPeripheral
 
+from vendor.i2c                                  import I2CPeripheral
+
 CLOCK_FREQUENCIES_MHZ = {
     'sync': 60
 }
@@ -33,6 +35,12 @@ class HelloSoc(Elaboratable):
         self.uart_pins = Record([
             ('rx', [('i', 1)]),
             ('tx', [('o', 1)])
+        ])
+
+        # create a stand-in for our I2C pins
+        self.i2c_pins = Record([
+            ('sda', [('i', 1), ('o', 1), ('oe', 1)]),
+            ('scl', [('i', 1), ('o', 1), ('oe', 1)]),
         ])
 
         # create our SoC
@@ -60,6 +68,10 @@ class HelloSoc(Elaboratable):
         # ... add our LED peripheral, for simple output ...
         self.leds = LedPeripheral()
         self.soc.add_peripheral(self.leds, addr=0xf0001000)
+
+        # ... add an I2C transciever
+        self.i2c0 = I2CPeripheral(pads=self.i2c_pins, period_cyc=240)
+        self.soc.add_peripheral(self.i2c0, addr=0xf0002000)
 
         super().__init__()
 

--- a/gateware/src/example_soc/top.py
+++ b/gateware/src/example_soc/top.py
@@ -20,7 +20,7 @@ from luna_soc.util.readbin                       import get_mem_data
 from tiliqua.tiliqua_platform                    import TiliquaPlatform
 from tiliqua.psram_peripheral                    import PSRAMPeripheral
 
-from vendor.i2c                                  import I2CPeripheral
+from tiliqua.i2c                                 import I2CPeripheral
 
 CLOCK_FREQUENCIES_MHZ = {
     'sync': 60

--- a/gateware/src/tiliqua/i2c.py
+++ b/gateware/src/tiliqua/i2c.py
@@ -1,4 +1,6 @@
-# This file re-uses some of `interfaces/i2c` from LUNA.
+# Transaction-based I2C peripheral.
+#
+# This file is built on `interfaces/i2c` from LUNA.
 #
 # Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
 # Copyright (c) 2024 S. Holzapfel, apfelaudio UG <info@apfelaudio.com>
@@ -11,6 +13,65 @@ from luna.gateware.interface.i2c import I2CInitiator
 from luna_soc.gateware.csr.base  import Peripheral
 
 class I2CPeripheral(Peripheral, Elaboratable):
+
+    """Transaction-based I2C peripheral.
+
+    All I2C transactions (read + write) for a single address may
+    be enqueued on the transaction fifo at once. Once the core is
+    started, it will execute these transactions, and any read operations
+    encountered will append bytes to the rx fifo. On a NAK or other
+    error, both FIFOs are drained so the core is in a clean state,
+    and an `err` flag is asserted. To write to a new device address,
+    the address CSR must be written, and the core re-started.
+
+    The semantics of the transaction fifo are designed to match
+    the `transaction()` method from `embedded-hal-1.0.0`. The
+    contract of this method is repeated here for convenience:
+
+    source: https://github.com/rust-embedded/embedded-hal/blob/master/embedded-hal/src/i2c.rs
+    Transaction contract:
+    - Before executing the first operation an ST is sent automatically.
+      This is followed by `SAD+R/W`  as appropriate.
+    - Data from adjacent operations of the same type are sent after each
+      other without an `SP`  or `SR`.
+    - Between adjacent operations of a different type an `SR` and
+      `SAD+R/W` is sent.
+    - After executing the last operation an SP is sent automatically.
+    - If the last operation is a `Read` the master does not send an
+      acknowledge for the last byte.
+    - `ST` = start condition
+    - `SAD+R/W` = slave address followed by bit 1 to indicate reading or
+       0 to indicate writing
+    - `SR` = repeated start condition
+
+    CSR registers
+    -------------
+    start : write-only
+        Write a '1' to execute all transactions in the transaction FIFO.
+    busy : read-only
+        If the core is currently executing transactions, '1', else '0'.
+    address : write-only
+        7-bit address of the target I2C device for the transactions.
+    transaction_data : write-only
+        Transaction FIFO. 9-bit entries where the most-significant bit
+        should be 0 for write and 1 for read operations. The least
+        significant 8 bits are the data to write (for write transactions),
+        or simply ignored (for read transactions).
+    transaction_rdy : write-only
+        If there is space in the transaction FIFO, '1', else '0'.
+    rx_data : read-only
+        Read FIFO. 8-bit entries, one per successful read transaction.
+        This should only be read once 'busy' has deasserted.
+    err : read/write
+        Read FIFO. 8-bit entries, one per successful read transaction.
+
+    TODO
+    ----
+    - Add an 'abort' CSR to let the SoC drain our FIFOs if it decides
+      to abort a transaction midway through writing it (e.g. FIFOs full).
+    - Revise 'READ_RECV_VALUE' state. It should never ack the last read
+      byte per the transaction() contract.
+    """
 
     def __init__(self, *, pads, period_cyc, clk_stretch=False,
                  transaction_depth=32, rx_depth=8, **kwargs):
@@ -34,7 +95,7 @@ class I2CPeripheral(Peripheral, Elaboratable):
         self._start            = bank.csr(1, "w")
         self._address          = bank.csr(self.addr_width, "w")
         self._transaction_data = bank.csr(self.transaction_width, "w")
-        self._transactions_rdy = bank.csr(1, "r")
+        self._transaction_rdy = bank.csr(1, "r")
         self._rx_data          = bank.csr(self.data_width, "r")
         self._err              = bank.csr(1, "rw")
 
@@ -69,7 +130,7 @@ class I2CPeripheral(Peripheral, Elaboratable):
             # Transactions FIFO <- CSRs
             self._transactions.w_en       .eq(self._transaction_data.w_stb),
             self._transactions.w_data     .eq(self._transaction_data.w_data),
-            self._transactions_rdy.r_data .eq(self._transactions.w_rdy),
+            self._transaction_rdy.r_data .eq(self._transactions.w_rdy),
             # CSRs <- Rx FIFO
             self._rx_data.r_data          .eq(self._rx_fifo.r_data),
             self._rx_fifo.r_en            .eq(self._rx_data.r_stb),
@@ -183,9 +244,9 @@ class I2CPeripheral(Peripheral, Elaboratable):
                 with m.If(~i2c.busy):
                     m.d.sync += err.eq(1)
                     m.d.comb += i2c.stop.eq(1)
-                    m.next = "DRAIN-FIFOS"
+                    m.next = "DRAIN_FIFOS"
 
-            with m.State("DRAIN-FIFOS"):
+            with m.State("DRAIN_FIFOS"):
                 with m.If((self._transactions.level == 0) &
                           (self._rx_fifo.level == 0)):
                     m.next = "IDLE"

--- a/gateware/src/vendor/i2c.py
+++ b/gateware/src/vendor/i2c.py
@@ -1,0 +1,474 @@
+# amaranth: UnusedElaboratable=no
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2023 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Based on I2C code from Glasgow
+# I2C reference: https://www.nxp.com/docs/en/user-guide/UM10204.pdf
+
+from amaranth import Elaboratable, Module, Signal, Cat, C
+from amaranth.lib.cdc import FFSynchronizer
+from amaranth.hdl.rec import Record, DIR_FANIN, DIR_FANOUT
+
+
+__all__ = ["I2CBus", "I2CInitiator", "I2CRegisterInterface"]
+
+class I2CBus(Record):
+    """ Record representing an I2C bus. """
+    def __init__(self):
+        super().__init__([
+            ('scl', [('i', 1, DIR_FANIN), ('o', 1, DIR_FANOUT), ('oe', 1, DIR_FANOUT)]),
+            ('sda', [('i', 1, DIR_FANIN), ('o', 1, DIR_FANOUT), ('oe', 1, DIR_FANOUT)]),
+        ])
+
+class I2CRegisterInterface(Elaboratable):
+    """ Gateware interface that handles I2C register reads and writes.
+
+    I/O ports:
+
+        # Controller signals:
+        O: busy              -- indicates when the interface is busy processing a transaction
+        I: address[8]        -- the address of the register to work with
+        O: done              -- strobe that indicates when a register request is complete
+
+        I: read_request      -- strobe that requests a register read
+        O: read_data[8]      -- data read from the relevant register read
+
+        I: write_request     -- strobe that indicates a register write
+        I: write_data[8]     -- data to be written during a register write
+
+    """
+    def __init__(self, pads, *, period_cyc, address, clk_stretch=False, data_bytes=1):
+
+        self.pads          = pads
+        self.period_cyc    = period_cyc
+        self.dev_address   = address
+        self.clk_stretch   = clk_stretch
+
+        # I/O ports
+
+        self.busy          = Signal()
+        self.address       = Signal(8)
+        self.size          = Signal(range(data_bytes+1))
+        self.done          = Signal()
+
+        self.read_request  = Signal()
+        self.read_data     = Signal(8 * data_bytes)
+
+        self.write_request = Signal()
+        self.write_data    = Signal(8 * data_bytes)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        current_address = Signal.like(self.address, reset_less=True)
+        current_write   = Signal.like(self.write_data, reset_less=True)
+        current_read    = Signal.like(self.read_data - 8, reset_less=True)
+        rem_bytes       = Signal.like(self.size, reset_less=True)
+        is_write        = Signal(reset_less=True)
+
+        # I2C initiator (low level manager) and default signal values
+        m.submodules.i2c = i2c = I2CInitiator(pads=self.pads, period_cyc=self.period_cyc, clk_stretch=self.clk_stretch)
+        m.d.comb += [
+            i2c.start .eq(0),
+            i2c.write .eq(0),
+            i2c.read  .eq(0),
+            i2c.stop  .eq(0),
+        ]
+
+        with m.FSM() as fsm:
+
+            # We're busy whenever we're not IDLE; indicate so.
+            m.d.comb += self.busy.eq(~fsm.ongoing('IDLE'))
+
+            # IDLE: wait for a request to be made
+            with m.State('IDLE'):
+                with m.If(self.read_request | self.write_request):
+                    m.d.sync += [
+                        current_address .eq(self.address),
+                        current_write   .eq(self.write_data),
+                        current_read    .eq(0),
+                        rem_bytes       .eq(self.size),
+                        is_write        .eq(self.write_request),
+                    ]
+                    m.next = 'START'
+
+            # Common device and register address handling
+            with m.State('START'):
+                with m.If(~i2c.busy):
+                    m.d.comb += i2c.start.eq(1)
+                    m.next = 'SEND_DEV_ADDRESS'
+
+            with m.State("SEND_DEV_ADDRESS"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        i2c.data_i.eq((self.dev_address << 1) | 0),
+                        i2c.write .eq(1),
+                    ]
+                    m.next = "ACK_DEV_ADDRESS"
+
+            with m.State("ACK_DEV_ADDRESS"):
+                with m.If(~i2c.busy):
+                    with m.If(i2c.ack_o):  # dev address asserted
+                        m.next = "SEND_REG_ADDRESS"
+                    with m.Else():
+                        m.next = "ABORT"
+
+            with m.State("SEND_REG_ADDRESS"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        i2c.data_i.eq(current_address),
+                        i2c.write .eq(1),
+                    ]
+                    m.next = "ACK_REG_ADDRESS"
+
+            with m.State("ACK_REG_ADDRESS"):
+                with m.If(~i2c.busy):
+                    with m.If(~i2c.ack_o):
+                        m.next = "ABORT"   # register address not asserted
+                    with m.Elif(rem_bytes == 0):
+                        m.next = "FINISH"  # 0-byte read/write
+                    with m.Elif(is_write):
+                        m.next = "WR_SEND_VALUE"
+                    with m.Else():
+                        m.next = "RD_START"
+
+            # Write states
+            # These handle the transmission of the successive bytes in the 
+            # current write request
+
+            with m.State("WR_SEND_VALUE"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        i2c.data_i.eq(current_write[-8:]),
+                        i2c.write .eq(1),
+                    ]
+                    # prepare next byte too
+                    m.d.sync += [
+                        current_write.eq(current_write << 8),
+                        rem_bytes    .eq(rem_bytes - 1),
+                    ]
+                    m.next = "WR_ACK_VALUE"
+            
+            with m.State("WR_ACK_VALUE"):
+                with m.If(~i2c.busy):
+                    with m.If(~i2c.ack_o):
+                        m.next = "ABORT"
+                    with m.Elif(rem_bytes == 0):
+                        m.next = "FINISH"
+                    with m.Else():
+                        m.next = "WR_SEND_VALUE"
+
+            # Read states
+            # Once the source register address is written in the common states,
+            # the following handles the retrieval of bytes from the device with
+            # a new I2C read request.
+
+            with m.State('RD_START'):
+                with m.If(~i2c.busy):
+                    m.d.comb += i2c.start.eq(1)
+                    m.next = 'RD_SEND_DEV_ADDRESS'
+
+            with m.State("RD_SEND_DEV_ADDRESS"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        i2c.data_i.eq((self.dev_address << 1) | 1),
+                        i2c.write .eq(1),
+                    ]
+                    m.next = "RD_ACK_DEV_ADDRESS"
+
+            with m.State("RD_ACK_DEV_ADDRESS"):
+                with m.If(~i2c.busy):
+                    with m.If(i2c.ack_o):  # dev address asserted
+                        m.next = "RD_RECV_VALUE"
+                    with m.Else():
+                        m.next = "ABORT"
+
+            with m.State("RD_RECV_VALUE"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        i2c.ack_i.eq(~(rem_bytes == 1)),  # 0 in last read byte
+                        i2c.read .eq(1),
+                    ]
+                    m.d.sync += rem_bytes.eq(rem_bytes - 1)
+                    m.next = "RD_WAIT_VALUE"
+
+            with m.State("RD_WAIT_VALUE"):
+                with m.If(~i2c.busy):
+                    m.d.sync += current_read.eq((current_read << 8) | i2c.data_o)
+                    with m.If(rem_bytes == 0):
+                        m.d.sync += self.read_data.eq((current_read << 8) | i2c.data_o)
+                        m.next = "FINISH"
+                    with m.Else():
+                        m.next = "RD_RECV_VALUE"
+
+            # Common "exit" states that return to idle
+            # FINISH asserts "done" to tell the transfer was done successfully
+            with m.State("FINISH"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        i2c.stop .eq(1),
+                        self.done.eq(1),
+                    ]
+                    m.next = "IDLE"
+            
+            with m.State("ABORT"):
+                with m.If(~i2c.busy):
+                    m.d.comb += i2c.stop .eq(1)
+                    m.next = "IDLE"
+
+        return m
+
+
+class I2CBusDriver(Elaboratable):
+    """
+    Decodes bus conditions (start, stop, sample and setup) and provides synchronization.
+    """
+    def __init__(self, pads):
+        self.scl_t  = pads.scl_t if hasattr(pads, "scl_t") else pads.scl
+        self.sda_t  = pads.sda_t if hasattr(pads, "sda_t") else pads.sda
+
+        self.scl_i  = Signal()
+        self.scl_o  = Signal(reset=1)
+        self.sda_i  = Signal()
+        self.sda_o  = Signal(reset=1)
+
+        self.sample = Signal(name="bus_sample")
+        self.setup  = Signal(name="bus_setup")
+        self.start  = Signal(name="bus_start")
+        self.stop   = Signal(name="bus_stop")
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # SDA line must be bidirectional...
+        m.d.comb += [
+            self.sda_t.o  .eq(0),
+            self.sda_t.oe .eq(~self.sda_o),
+        ]
+        m.submodules += FFSynchronizer(self.sda_t.i, self.sda_i, reset=1)
+
+        # But the SCL line does not need to: only if we want to support clock stretching
+        if hasattr(self.scl_t, "oe"):
+            m.d.comb += [
+                self.scl_t.o  .eq(0),
+                self.scl_t.oe .eq(~self.scl_o),
+            ]
+            m.submodules += FFSynchronizer(self.scl_t.i, self.scl_i, reset=1)
+        else:
+            # SCL output only
+            m.d.comb += [
+                self.scl_t.o  .eq(self.scl_o),
+                self.scl_i    .eq(self.scl_o),
+            ]
+
+        # Additional signals for bus state detection
+        scl_r = Signal(reset=1)
+        sda_r = Signal(reset=1)
+        m.d.sync += [
+            scl_r.eq(self.scl_i),
+            sda_r.eq(self.sda_i),
+        ]
+        m.d.comb += [
+            self.sample .eq(~scl_r & self.scl_i),  # SCL rising edge
+            self.setup  .eq(scl_r & ~self.scl_i),  # SCL falling edge
+            self.start  .eq(self.scl_i & sda_r & ~self.sda_i),  # SDA fall, SCL high
+            self.stop   .eq(self.scl_i & ~sda_r & self.sda_i),  # SDA rise, SCL high
+        ]
+        
+        return m
+
+
+class I2CInitiator(Elaboratable):
+    """
+    Simple I2C transaction initiator.
+
+    Generates start and stop conditions, and transmits and receives octets.
+    Clock stretching is supported.
+
+    :param period_cyc:
+        Bus clock period, as a multiple of system clock period.
+    :type period_cyc: int
+    :param clk_stretch:
+        If true, SCL will be monitored for devices stretching the clock. Otherwise,
+        only internally generated SCL is considered.
+    :type clk_stretch: bool
+
+    :attr busy:
+        Busy flag. Low if the state machine is idle, high otherwise.
+    :attr start:
+        Start strobe. When ``busy`` is low, asserting ``start`` for one cycle generates
+        a start or repeated start condition on the bus. Ignored when ``busy`` is high.
+    :attr stop:
+        Stop strobe. When ``busy`` is low, asserting ``stop`` for one cycle generates
+        a stop condition on the bus. Ignored when ``busy`` is high.
+    :attr write:
+        Write strobe. When ``busy`` is low, asserting ``write`` for one cycle latches
+        ``data_i`` and transmits it on the bus, after which the acknowledge bit
+        from the bus is latched to ``ack_o``. Ignored when ``busy`` is high.
+    :attr data_i:
+        Data octet to be transmitted. Latched immediately after ``write`` is asserted.
+    :attr ack_o:
+        Received acknowledge bit.
+    :attr read:
+        Read strobe. 
+        When ``busy`` is low, asserting ``read`` for one cycle receives an octet on 
+        the bus and latches it to ``data_o``, after which the acknowledge bit is 
+        asserted if ``ack_i`` is high. Ignored when ``busy`` is high.
+    :attr data_o:
+        Received data octet.
+    :attr ack_i:
+        Acknowledge bit to be transmitted. Latched immediately after ``read`` is asserted.
+    """
+    def __init__(self, pads, period_cyc, clk_stretch=True):
+        self.bus         = I2CBusDriver(pads)
+        self.period_cyc  = int(period_cyc)
+        self.clk_stretch = clk_stretch
+
+        self.busy   = Signal(reset=1)
+        self.start  = Signal()
+        self.stop   = Signal()
+        self.read   = Signal()
+        self.data_i = Signal(8)
+        self.ack_o  = Signal()
+        self.write  = Signal()
+        self.data_o = Signal(8)
+        self.ack_i  = Signal()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.bus = bus = self.bus
+
+        timer = Signal(range(self.period_cyc))
+        stb   = Signal()
+
+        with m.If((timer == 0) | ~self.busy):
+            m.d.sync += timer.eq(self.period_cyc // 4)
+        with m.Elif((not self.clk_stretch) | (bus.scl_o == bus.scl_i)):
+            m.d.sync += timer.eq(timer - 1)
+
+        m.d.comb += stb.eq(timer == 0)
+
+        bitno   = Signal(range(8))
+        r_shreg = Signal(8)
+        w_shreg = Signal(8)
+        r_ack   = Signal()
+        
+        with m.FSM() as fsm:
+            self._fsm = fsm
+            def scl_l(state, next_state, *exprs):
+                with m.State(state):
+                    with m.If(stb):
+                        m.d.sync += self.bus.scl_o.eq(0)
+                        m.next = next_state
+                        m.d.sync += exprs
+
+            def scl_h(state, next_state, *exprs):
+                with m.State(state):
+                    with m.If(stb):
+                        m.d.sync += self.bus.scl_o.eq(1)
+                    with m.Elif(self.bus.scl_o == 1):
+                        with m.If((not self.clk_stretch) | (self.bus.scl_i == 1)):
+                            m.next = next_state
+                            m.d.sync += exprs
+
+            def stb_x(state, next_state, *exprs, bit7_next_state=None):
+                with m.State(state):
+                    with m.If(stb):
+                        m.next = next_state
+                        if bit7_next_state is not None:
+                            with m.If(bitno == 7):
+                                m.next = bit7_next_state
+                        m.d.sync += exprs
+
+            with m.State("IDLE"):
+                m.d.sync += self.busy.eq(1)
+                with m.If(self.start):
+                    with m.If(bus.scl_i & bus.sda_i):
+                        m.next = "START-SDA-L"
+                    with m.Elif(~bus.scl_i):
+                        m.next = "START-SCL-H"
+                    with m.Elif(bus.scl_i):
+                        m.next = "START-SCL-L"
+                with m.Elif(self.stop):
+                    with m.If(bus.scl_i & ~bus.sda_o):
+                        m.next = "STOP-SDA-H"
+                    with m.Elif(~bus.scl_i):
+                        m.next = "STOP-SCL-H"
+                    with m.Elif(bus.scl_i):
+                        m.next = "STOP-SCL-L"
+                with m.Elif(self.write):
+                    m.d.sync += w_shreg.eq(self.data_i)
+                    m.next = "WRITE-DATA-SCL-L"
+                with m.Elif(self.read):
+                    m.d.sync += r_ack.eq(self.ack_i)
+                    m.next = "READ-DATA-SCL-L"
+                with m.Else():
+                    m.d.sync += self.busy.eq(0)
+            
+            # start
+            scl_l("START-SCL-L", "START-SDA-H")
+            stb_x("START-SDA-H", "START-SCL-H",
+                self.bus.sda_o.eq(1)
+            )
+            scl_h("START-SCL-H", "START-SDA-L")
+            stb_x("START-SDA-L", "IDLE",
+                self.bus.sda_o.eq(0)
+            )
+            # stop
+            scl_l("STOP-SCL-L",  "STOP-SDA-L")
+            stb_x("STOP-SDA-L",  "STOP-SCL-H",
+                self.bus.sda_o.eq(0)
+            )
+            scl_h("STOP-SCL-H",  "STOP-SDA-H")
+            stb_x("STOP-SDA-H",  "IDLE",
+                self.bus.sda_o.eq(1)
+            )
+            # write data
+            scl_l("WRITE-DATA-SCL-L", "WRITE-DATA-SDA-X")
+            stb_x("WRITE-DATA-SDA-X", "WRITE-DATA-SCL-H",
+                self.bus.sda_o.eq(w_shreg[7])
+            )
+            scl_h("WRITE-DATA-SCL-H", "WRITE-DATA-SDA-N",
+                w_shreg.eq(Cat(C(0, 1), w_shreg[0:7]))
+            )
+            stb_x("WRITE-DATA-SDA-N", "WRITE-DATA-SCL-L",
+                bitno.eq(bitno + 1),
+                bit7_next_state="WRITE-ACK-SCL-L"
+            )
+            # write ack
+            scl_l("WRITE-ACK-SCL-L", "WRITE-ACK-SDA-H")
+            stb_x("WRITE-ACK-SDA-H", "WRITE-ACK-SCL-H",
+                self.bus.sda_o.eq(1)
+            )
+            scl_h("WRITE-ACK-SCL-H", "WRITE-ACK-SDA-N",
+                self.ack_o.eq(~self.bus.sda_i)
+            )
+            stb_x("WRITE-ACK-SDA-N", "IDLE")
+            # read data
+            scl_l("READ-DATA-SCL-L", "READ-DATA-SDA-H")
+            stb_x("READ-DATA-SDA-H", "READ-DATA-SCL-H",
+                self.bus.sda_o.eq(1)
+            )
+            scl_h("READ-DATA-SCL-H", "READ-DATA-SDA-N",
+                r_shreg.eq(Cat(self.bus.sda_i, r_shreg[0:7]))
+            )
+            stb_x("READ-DATA-SDA-N", "READ-DATA-SCL-L",
+                bitno.eq(bitno + 1),
+                bit7_next_state="READ-ACK-SCL-L"
+            )
+            # read ack
+            scl_l("READ-ACK-SCL-L", "READ-ACK-SDA-X")
+            stb_x("READ-ACK-SDA-X", "READ-ACK-SCL-H",
+                self.bus.sda_o.eq(~r_ack)
+            )
+            scl_h("READ-ACK-SCL-H", "READ-ACK-SDA-N",
+                self.data_o.eq(r_shreg)
+            )
+            stb_x("READ-ACK-SDA-N", "IDLE")
+
+        return m
+

--- a/gateware/src/vendor/i2c.py
+++ b/gateware/src/vendor/i2c.py
@@ -56,11 +56,14 @@ class I2CPeripheral(Peripheral, Elaboratable):
         m.submodules.rx_fifo = self._rx_fifo
         m.submodules.transactions = self._transactions
 
+        err = Signal()
+
         with m.If(self._address.w_stb):
             m.d.sync += self.address.eq(self._address.w_data)
 
+        m.d.comb += self._err.r_data.eq(err)
         with m.If(self._err.w_stb):
-            m.d.sync += self._err.r_data.eq(self._err.w_data)
+            m.d.sync += err.eq(self._err.w_data)
 
         m.d.comb += [
             # Transactions FIFO <- CSRs
@@ -178,7 +181,7 @@ class I2CPeripheral(Peripheral, Elaboratable):
 
             with m.State("ABORT"):
                 with m.If(~i2c.busy):
-                    m.d.sync += self._err.r_data.eq(1)
+                    m.d.sync += err.eq(1)
                     m.d.comb += i2c.stop.eq(1)
                     m.next = "DRAIN-FIFOS"
 

--- a/gateware/src/vendor/i2c.py
+++ b/gateware/src/vendor/i2c.py
@@ -1,73 +1,79 @@
-# amaranth: UnusedElaboratable=no
+# This file re-uses some of `interfaces/i2c` from LUNA.
 #
-# This file is part of LUNA.
+# Copyright (c) 2020 Great Scott Gadgets <info@greatscottgadgets.com>
+# Copyright (c) 2024 S. Holzapfel, apfelaudio UG <info@apfelaudio.com>
 #
-# Copyright (c) 2023 Great Scott Gadgets <info@greatscottgadgets.com>
 # SPDX-License-Identifier: BSD-3-Clause
-#
-# Based on I2C code from Glasgow
-# I2C reference: https://www.nxp.com/docs/en/user-guide/UM10204.pdf
 
-from amaranth import Elaboratable, Module, Signal, Cat, C
-from amaranth.lib.cdc import FFSynchronizer
-from amaranth.hdl.rec import Record, DIR_FANIN, DIR_FANOUT
+from amaranth                    import *
+from amaranth.lib.fifo           import SyncFIFO
+from luna.gateware.interface.i2c import I2CInitiator
+from luna_soc.gateware.csr.base  import Peripheral
 
+class I2CPeripheral(Peripheral, Elaboratable):
 
-__all__ = ["I2CBus", "I2CInitiator", "I2CRegisterInterface"]
+    def __init__(self, *, pads, period_cyc, clk_stretch=False,
+                 transaction_depth=32, rx_depth=8, **kwargs):
 
-class I2CBus(Record):
-    """ Record representing an I2C bus. """
-    def __init__(self):
-        super().__init__([
-            ('scl', [('i', 1, DIR_FANIN), ('o', 1, DIR_FANOUT), ('oe', 1, DIR_FANOUT)]),
-            ('sda', [('i', 1, DIR_FANIN), ('o', 1, DIR_FANOUT), ('oe', 1, DIR_FANOUT)]),
-        ])
-
-class I2CRegisterInterface(Elaboratable):
-    """ Gateware interface that handles I2C register reads and writes.
-
-    I/O ports:
-
-        # Controller signals:
-        O: busy              -- indicates when the interface is busy processing a transaction
-        I: address[8]        -- the address of the register to work with
-        O: done              -- strobe that indicates when a register request is complete
-
-        I: read_request      -- strobe that requests a register read
-        O: read_data[8]      -- data read from the relevant register read
-
-        I: write_request     -- strobe that indicates a register write
-        I: write_data[8]     -- data to be written during a register write
-
-    """
-    def __init__(self, pads, *, period_cyc, address, clk_stretch=False, data_bytes=1):
+        super().__init__()
 
         self.pads          = pads
         self.period_cyc    = period_cyc
-        self.dev_address   = address
         self.clk_stretch   = clk_stretch
 
-        # I/O ports
+        self.data_width        = 8
+        self.addr_width        = 7
+        self.transaction_width = self.data_width + 1
 
-        self.busy          = Signal()
-        self.address       = Signal(8)
-        self.size          = Signal(range(data_bytes+1))
-        self.done          = Signal()
+        self._transactions = SyncFIFO(width=self.transaction_width, depth=transaction_depth)
+        self._rx_fifo      = SyncFIFO(width=self.data_width, depth=rx_depth)
 
-        self.read_request  = Signal()
-        self.read_data     = Signal(8 * data_bytes)
+        # CSRs
+        bank                   = self.csr_bank()
+        self._busy             = bank.csr(1, "r")
+        self._start            = bank.csr(1, "w")
+        self._address          = bank.csr(self.addr_width, "w")
+        self._transaction_data = bank.csr(self.transaction_width, "w")
+        self._transactions_rdy = bank.csr(1, "r")
+        self._rx_data          = bank.csr(self.data_width, "r")
+        self._err              = bank.csr(1, "rw")
 
-        self.write_request = Signal()
-        self.write_data    = Signal(8 * data_bytes)
+        # Storage for CSRs
+        self.address           = Signal(self.addr_width)
+
+        # Wires to the last transaction FIFO output
+        self.transaction_rw    = Signal()
+        self.transaction_data  = Signal(self.data_width)
+
+        # Peripheral bus
+        self._bridge    = self.bridge(data_width=32, granularity=8, alignment=2)
+        self.bus        = self._bridge.bus
 
     def elaborate(self, platform):
         m = Module()
 
-        current_address = Signal.like(self.address, reset_less=True)
-        current_write   = Signal.like(self.write_data, reset_less=True)
-        current_read    = Signal.like(self.read_data - 8, reset_less=True)
-        rem_bytes       = Signal.like(self.size, reset_less=True)
-        is_write        = Signal(reset_less=True)
+        m.submodules.bridge  = self._bridge
+        m.submodules.rx_fifo = self._rx_fifo
+        m.submodules.transactions = self._transactions
+
+        with m.If(self._address.w_stb):
+            m.d.sync += self.address.eq(self._address.w_data)
+
+        with m.If(self._err.w_stb):
+            m.d.sync += self._err.r_data.eq(self._err.w_data)
+
+        m.d.comb += [
+            # Transactions FIFO <- CSRs
+            self._transactions.w_en       .eq(self._transaction_data.w_stb),
+            self._transactions.w_data     .eq(self._transaction_data.w_data),
+            self._transactions_rdy.r_data .eq(self._transactions.w_rdy),
+            # CSRs <- Rx FIFO
+            self._rx_data.r_data          .eq(self._rx_fifo.r_data),
+            self._rx_fifo.r_en            .eq(self._rx_data.r_stb),
+            # PHY <- Transactions FIFO
+            self.transaction_rw          .eq(self._transactions.r_data[8]),
+            self.transaction_data        .eq(self._transactions.r_data[0:8]),
+        ]
 
         # I2C initiator (low level manager) and default signal values
         m.submodules.i2c = i2c = I2CInitiator(pads=self.pads, period_cyc=self.period_cyc, clk_stretch=self.clk_stretch)
@@ -78,397 +84,110 @@ class I2CRegisterInterface(Elaboratable):
             i2c.stop  .eq(0),
         ]
 
+        current_transaction_rw = Signal()
+        transaction_stb        = Signal()
+        last_transaction       = Signal()
+
+        m.d.comb += self._transactions.r_en.eq(transaction_stb)
+        m.d.comb += last_transaction.eq(self._transactions.level == 0)
+
         with m.FSM() as fsm:
 
             # We're busy whenever we're not IDLE; indicate so.
-            m.d.comb += self.busy.eq(~fsm.ongoing('IDLE'))
+            m.d.comb += self._busy.r_data.eq(~fsm.ongoing('IDLE'))
 
-            # IDLE: wait for a request to be made
             with m.State('IDLE'):
-                with m.If(self.read_request | self.write_request):
-                    m.d.sync += [
-                        current_address .eq(self.address),
-                        current_write   .eq(self.write_data),
-                        current_read    .eq(0),
-                        rem_bytes       .eq(self.size),
-                        is_write        .eq(self.write_request),
-                    ]
+                with m.If(self._start.w_stb & self._start.w_data):
                     m.next = 'START'
 
-            # Common device and register address handling
             with m.State('START'):
                 with m.If(~i2c.busy):
-                    m.d.comb += i2c.start.eq(1)
+                    m.d.comb += i2c.start.eq(1),
                     m.next = 'SEND_DEV_ADDRESS'
 
             with m.State("SEND_DEV_ADDRESS"):
                 with m.If(~i2c.busy):
                     m.d.comb += [
-                        i2c.data_i.eq((self.dev_address << 1) | 0),
-                        i2c.write .eq(1),
+                        i2c.data_i     .eq((self.address << 1) | self.transaction_rw),
+                        i2c.write      .eq(1),
                     ]
+                    m.d.sync += current_transaction_rw.eq(self.transaction_rw)
                     m.next = "ACK_DEV_ADDRESS"
 
             with m.State("ACK_DEV_ADDRESS"):
                 with m.If(~i2c.busy):
-                    with m.If(i2c.ack_o):  # dev address asserted
-                        m.next = "SEND_REG_ADDRESS"
-                    with m.Else():
-                        m.next = "ABORT"
-
-            with m.State("SEND_REG_ADDRESS"):
-                with m.If(~i2c.busy):
-                    m.d.comb += [
-                        i2c.data_i.eq(current_address),
-                        i2c.write .eq(1),
-                    ]
-                    m.next = "ACK_REG_ADDRESS"
-
-            with m.State("ACK_REG_ADDRESS"):
-                with m.If(~i2c.busy):
-                    with m.If(~i2c.ack_o):
-                        m.next = "ABORT"   # register address not asserted
-                    with m.Elif(rem_bytes == 0):
-                        m.next = "FINISH"  # 0-byte read/write
-                    with m.Elif(is_write):
-                        m.next = "WR_SEND_VALUE"
-                    with m.Else():
-                        m.next = "RD_START"
-
-            # Write states
-            # These handle the transmission of the successive bytes in the 
-            # current write request
-
-            with m.State("WR_SEND_VALUE"):
-                with m.If(~i2c.busy):
-                    m.d.comb += [
-                        i2c.data_i.eq(current_write[-8:]),
-                        i2c.write .eq(1),
-                    ]
-                    # prepare next byte too
-                    m.d.sync += [
-                        current_write.eq(current_write << 8),
-                        rem_bytes    .eq(rem_bytes - 1),
-                    ]
-                    m.next = "WR_ACK_VALUE"
-            
-            with m.State("WR_ACK_VALUE"):
-                with m.If(~i2c.busy):
                     with m.If(~i2c.ack_o):
                         m.next = "ABORT"
-                    with m.Elif(rem_bytes == 0):
+                    with m.Elif(last_transaction):
+                        # zero-length transaction
                         m.next = "FINISH"
-                    with m.Else():
-                        m.next = "WR_SEND_VALUE"
-
-            # Read states
-            # Once the source register address is written in the common states,
-            # the following handles the retrieval of bytes from the device with
-            # a new I2C read request.
-
-            with m.State('RD_START'):
-                with m.If(~i2c.busy):
-                    m.d.comb += i2c.start.eq(1)
-                    m.next = 'RD_SEND_DEV_ADDRESS'
-
-            with m.State("RD_SEND_DEV_ADDRESS"):
-                with m.If(~i2c.busy):
-                    m.d.comb += [
-                        i2c.data_i.eq((self.dev_address << 1) | 1),
-                        i2c.write .eq(1),
-                    ]
-                    m.next = "RD_ACK_DEV_ADDRESS"
-
-            with m.State("RD_ACK_DEV_ADDRESS"):
-                with m.If(~i2c.busy):
-                    with m.If(i2c.ack_o):  # dev address asserted
+                    with m.Elif(current_transaction_rw != self.transaction_rw):
+                        # zero-length transaction
+                        m.next = "START"
+                    with m.Elif(current_transaction_rw == 1):
                         m.next = "RD_RECV_VALUE"
                     with m.Else():
-                        m.next = "ABORT"
+                        m.next = "WR_SEND_VALUE"
 
             with m.State("RD_RECV_VALUE"):
                 with m.If(~i2c.busy):
                     m.d.comb += [
-                        i2c.ack_i.eq(~(rem_bytes == 1)),  # 0 in last read byte
-                        i2c.read .eq(1),
+                        transaction_stb.eq(1),
+                        i2c.ack_i      .eq(1), # FIXME:  0 in last read byte
+                        i2c.read       .eq(1),
                     ]
-                    m.d.sync += rem_bytes.eq(rem_bytes - 1)
                     m.next = "RD_WAIT_VALUE"
 
             with m.State("RD_WAIT_VALUE"):
                 with m.If(~i2c.busy):
-                    m.d.sync += current_read.eq((current_read << 8) | i2c.data_o)
-                    with m.If(rem_bytes == 0):
-                        m.d.sync += self.read_data.eq((current_read << 8) | i2c.data_o)
+                    m.d.comb += [
+                        self._rx_fifo.w_data.eq(i2c.data_o),
+                        self._rx_fifo.w_en.eq(1),
+                    ]
+                    with m.If(last_transaction):
                         m.next = "FINISH"
+                    with m.Elif(self.transaction_rw != 1):
+                        m.next = "START"
                     with m.Else():
                         m.next = "RD_RECV_VALUE"
 
-            # Common "exit" states that return to idle
-            # FINISH asserts "done" to tell the transfer was done successfully
-            with m.State("FINISH"):
+            with m.State("WR_SEND_VALUE"):
                 with m.If(~i2c.busy):
                     m.d.comb += [
-                        i2c.stop .eq(1),
-                        self.done.eq(1),
+                        transaction_stb.eq(1),
+                        i2c.data_i     .eq(self.transaction_data),
+                        i2c.write      .eq(1),
                     ]
+                    m.next = "WR_ACK_VALUE"
+
+            with m.State("WR_ACK_VALUE"):
+                with m.If(~i2c.busy):
+                    with m.If(~i2c.ack_o):
+                        m.next = "ABORT"
+                    with m.Elif(last_transaction):
+                        m.next = "FINISH"
+                    with m.Elif(self.transaction_rw != 0):
+                        m.next = "START"
+                    with m.Else():
+                        m.next = "WR_SEND_VALUE"
+
+            with m.State("FINISH"):
+                with m.If(~i2c.busy):
+                    m.d.comb += i2c.stop.eq(1),
                     m.next = "IDLE"
-            
+
             with m.State("ABORT"):
                 with m.If(~i2c.busy):
-                    m.d.comb += i2c.stop .eq(1)
+                    m.d.sync += self._err.r_data.eq(1)
+                    m.d.comb += i2c.stop.eq(1)
+                    m.next = "DRAIN-FIFOS"
+
+            with m.State("DRAIN-FIFOS"):
+                with m.If((self._transactions.level == 0) &
+                          (self._rx_fifo.level == 0)):
                     m.next = "IDLE"
-
-        return m
-
-
-class I2CBusDriver(Elaboratable):
-    """
-    Decodes bus conditions (start, stop, sample and setup) and provides synchronization.
-    """
-    def __init__(self, pads):
-        self.scl_t  = pads.scl_t if hasattr(pads, "scl_t") else pads.scl
-        self.sda_t  = pads.sda_t if hasattr(pads, "sda_t") else pads.sda
-
-        self.scl_i  = Signal()
-        self.scl_o  = Signal(reset=1)
-        self.sda_i  = Signal()
-        self.sda_o  = Signal(reset=1)
-
-        self.sample = Signal(name="bus_sample")
-        self.setup  = Signal(name="bus_setup")
-        self.start  = Signal(name="bus_start")
-        self.stop   = Signal(name="bus_stop")
-
-    def elaborate(self, platform):
-        m = Module()
-
-        # SDA line must be bidirectional...
-        m.d.comb += [
-            self.sda_t.o  .eq(0),
-            self.sda_t.oe .eq(~self.sda_o),
-        ]
-        m.submodules += FFSynchronizer(self.sda_t.i, self.sda_i, reset=1)
-
-        # But the SCL line does not need to: only if we want to support clock stretching
-        if hasattr(self.scl_t, "oe"):
-            m.d.comb += [
-                self.scl_t.o  .eq(0),
-                self.scl_t.oe .eq(~self.scl_o),
-            ]
-            m.submodules += FFSynchronizer(self.scl_t.i, self.scl_i, reset=1)
-        else:
-            # SCL output only
-            m.d.comb += [
-                self.scl_t.o  .eq(self.scl_o),
-                self.scl_i    .eq(self.scl_o),
-            ]
-
-        # Additional signals for bus state detection
-        scl_r = Signal(reset=1)
-        sda_r = Signal(reset=1)
-        m.d.sync += [
-            scl_r.eq(self.scl_i),
-            sda_r.eq(self.sda_i),
-        ]
-        m.d.comb += [
-            self.sample .eq(~scl_r & self.scl_i),  # SCL rising edge
-            self.setup  .eq(scl_r & ~self.scl_i),  # SCL falling edge
-            self.start  .eq(self.scl_i & sda_r & ~self.sda_i),  # SDA fall, SCL high
-            self.stop   .eq(self.scl_i & ~sda_r & self.sda_i),  # SDA rise, SCL high
-        ]
-        
-        return m
-
-
-class I2CInitiator(Elaboratable):
-    """
-    Simple I2C transaction initiator.
-
-    Generates start and stop conditions, and transmits and receives octets.
-    Clock stretching is supported.
-
-    :param period_cyc:
-        Bus clock period, as a multiple of system clock period.
-    :type period_cyc: int
-    :param clk_stretch:
-        If true, SCL will be monitored for devices stretching the clock. Otherwise,
-        only internally generated SCL is considered.
-    :type clk_stretch: bool
-
-    :attr busy:
-        Busy flag. Low if the state machine is idle, high otherwise.
-    :attr start:
-        Start strobe. When ``busy`` is low, asserting ``start`` for one cycle generates
-        a start or repeated start condition on the bus. Ignored when ``busy`` is high.
-    :attr stop:
-        Stop strobe. When ``busy`` is low, asserting ``stop`` for one cycle generates
-        a stop condition on the bus. Ignored when ``busy`` is high.
-    :attr write:
-        Write strobe. When ``busy`` is low, asserting ``write`` for one cycle latches
-        ``data_i`` and transmits it on the bus, after which the acknowledge bit
-        from the bus is latched to ``ack_o``. Ignored when ``busy`` is high.
-    :attr data_i:
-        Data octet to be transmitted. Latched immediately after ``write`` is asserted.
-    :attr ack_o:
-        Received acknowledge bit.
-    :attr read:
-        Read strobe. 
-        When ``busy`` is low, asserting ``read`` for one cycle receives an octet on 
-        the bus and latches it to ``data_o``, after which the acknowledge bit is 
-        asserted if ``ack_i`` is high. Ignored when ``busy`` is high.
-    :attr data_o:
-        Received data octet.
-    :attr ack_i:
-        Acknowledge bit to be transmitted. Latched immediately after ``read`` is asserted.
-    """
-    def __init__(self, pads, period_cyc, clk_stretch=True):
-        self.bus         = I2CBusDriver(pads)
-        self.period_cyc  = int(period_cyc)
-        self.clk_stretch = clk_stretch
-
-        self.busy   = Signal(reset=1)
-        self.start  = Signal()
-        self.stop   = Signal()
-        self.read   = Signal()
-        self.data_i = Signal(8)
-        self.ack_o  = Signal()
-        self.write  = Signal()
-        self.data_o = Signal(8)
-        self.ack_i  = Signal()
-
-    def elaborate(self, platform):
-        m = Module()
-
-        m.submodules.bus = bus = self.bus
-
-        timer = Signal(range(self.period_cyc))
-        stb   = Signal()
-
-        with m.If((timer == 0) | ~self.busy):
-            m.d.sync += timer.eq(self.period_cyc // 4)
-        with m.Elif((not self.clk_stretch) | (bus.scl_o == bus.scl_i)):
-            m.d.sync += timer.eq(timer - 1)
-
-        m.d.comb += stb.eq(timer == 0)
-
-        bitno   = Signal(range(8))
-        r_shreg = Signal(8)
-        w_shreg = Signal(8)
-        r_ack   = Signal()
-        
-        with m.FSM() as fsm:
-            self._fsm = fsm
-            def scl_l(state, next_state, *exprs):
-                with m.State(state):
-                    with m.If(stb):
-                        m.d.sync += self.bus.scl_o.eq(0)
-                        m.next = next_state
-                        m.d.sync += exprs
-
-            def scl_h(state, next_state, *exprs):
-                with m.State(state):
-                    with m.If(stb):
-                        m.d.sync += self.bus.scl_o.eq(1)
-                    with m.Elif(self.bus.scl_o == 1):
-                        with m.If((not self.clk_stretch) | (self.bus.scl_i == 1)):
-                            m.next = next_state
-                            m.d.sync += exprs
-
-            def stb_x(state, next_state, *exprs, bit7_next_state=None):
-                with m.State(state):
-                    with m.If(stb):
-                        m.next = next_state
-                        if bit7_next_state is not None:
-                            with m.If(bitno == 7):
-                                m.next = bit7_next_state
-                        m.d.sync += exprs
-
-            with m.State("IDLE"):
-                m.d.sync += self.busy.eq(1)
-                with m.If(self.start):
-                    with m.If(bus.scl_i & bus.sda_i):
-                        m.next = "START-SDA-L"
-                    with m.Elif(~bus.scl_i):
-                        m.next = "START-SCL-H"
-                    with m.Elif(bus.scl_i):
-                        m.next = "START-SCL-L"
-                with m.Elif(self.stop):
-                    with m.If(bus.scl_i & ~bus.sda_o):
-                        m.next = "STOP-SDA-H"
-                    with m.Elif(~bus.scl_i):
-                        m.next = "STOP-SCL-H"
-                    with m.Elif(bus.scl_i):
-                        m.next = "STOP-SCL-L"
-                with m.Elif(self.write):
-                    m.d.sync += w_shreg.eq(self.data_i)
-                    m.next = "WRITE-DATA-SCL-L"
-                with m.Elif(self.read):
-                    m.d.sync += r_ack.eq(self.ack_i)
-                    m.next = "READ-DATA-SCL-L"
                 with m.Else():
-                    m.d.sync += self.busy.eq(0)
-            
-            # start
-            scl_l("START-SCL-L", "START-SDA-H")
-            stb_x("START-SDA-H", "START-SCL-H",
-                self.bus.sda_o.eq(1)
-            )
-            scl_h("START-SCL-H", "START-SDA-L")
-            stb_x("START-SDA-L", "IDLE",
-                self.bus.sda_o.eq(0)
-            )
-            # stop
-            scl_l("STOP-SCL-L",  "STOP-SDA-L")
-            stb_x("STOP-SDA-L",  "STOP-SCL-H",
-                self.bus.sda_o.eq(0)
-            )
-            scl_h("STOP-SCL-H",  "STOP-SDA-H")
-            stb_x("STOP-SDA-H",  "IDLE",
-                self.bus.sda_o.eq(1)
-            )
-            # write data
-            scl_l("WRITE-DATA-SCL-L", "WRITE-DATA-SDA-X")
-            stb_x("WRITE-DATA-SDA-X", "WRITE-DATA-SCL-H",
-                self.bus.sda_o.eq(w_shreg[7])
-            )
-            scl_h("WRITE-DATA-SCL-H", "WRITE-DATA-SDA-N",
-                w_shreg.eq(Cat(C(0, 1), w_shreg[0:7]))
-            )
-            stb_x("WRITE-DATA-SDA-N", "WRITE-DATA-SCL-L",
-                bitno.eq(bitno + 1),
-                bit7_next_state="WRITE-ACK-SCL-L"
-            )
-            # write ack
-            scl_l("WRITE-ACK-SCL-L", "WRITE-ACK-SDA-H")
-            stb_x("WRITE-ACK-SDA-H", "WRITE-ACK-SCL-H",
-                self.bus.sda_o.eq(1)
-            )
-            scl_h("WRITE-ACK-SCL-H", "WRITE-ACK-SDA-N",
-                self.ack_o.eq(~self.bus.sda_i)
-            )
-            stb_x("WRITE-ACK-SDA-N", "IDLE")
-            # read data
-            scl_l("READ-DATA-SCL-L", "READ-DATA-SDA-H")
-            stb_x("READ-DATA-SDA-H", "READ-DATA-SCL-H",
-                self.bus.sda_o.eq(1)
-            )
-            scl_h("READ-DATA-SCL-H", "READ-DATA-SDA-N",
-                r_shreg.eq(Cat(self.bus.sda_i, r_shreg[0:7]))
-            )
-            stb_x("READ-DATA-SDA-N", "READ-DATA-SCL-L",
-                bitno.eq(bitno + 1),
-                bit7_next_state="READ-ACK-SCL-L"
-            )
-            # read ack
-            scl_l("READ-ACK-SCL-L", "READ-ACK-SDA-X")
-            stb_x("READ-ACK-SDA-X", "READ-ACK-SCL-H",
-                self.bus.sda_o.eq(~r_ack)
-            )
-            scl_h("READ-ACK-SCL-H", "READ-ACK-SDA-N",
-                self.data_o.eq(r_shreg)
-            )
-            stb_x("READ-ACK-SDA-N", "IDLE")
+                    m.d.comb += self._transactions.r_en.eq(1)
+                    m.d.comb += self._rx_fifo.r_en.eq(1)
 
         return m
-

--- a/gateware/tests/test_i2c.py
+++ b/gateware/tests/test_i2c.py
@@ -1,0 +1,90 @@
+import unittest
+
+from amaranth              import *
+from amaranth.sim          import *
+from vendor                import i2c
+
+class I2CTests(unittest.TestCase):
+
+    def test_i2c_tx(self):
+
+        class FakeTristate:
+            i  = Signal()
+            o  = Signal()
+            oe = Signal()
+
+        class FakeI2CPads:
+            sda = FakeTristate()
+            scl = FakeTristate()
+
+        i2c_pads = FakeI2CPads()
+
+        top = i2c.I2CPeripheral(pads=i2c_pads, period_cyc=4)
+
+        def testbench():
+            # initial
+            yield Tick()
+
+            # set device address
+            yield top._address.w_stb               .eq(1)
+            yield top._address.w_data              .eq(0x55)
+            yield Tick()
+
+            # enqueue 2x write ops
+            yield top._transaction_data.w_stb      .eq(1)
+            yield top._transaction_data.w_data     .eq(0x042)
+            yield Tick()
+            yield top._transaction_data.w_stb      .eq(1)
+            yield top._transaction_data.w_data     .eq(0x013)
+            yield Tick()
+
+            # enqueue 1x read op
+            yield top._transaction_data.w_stb      .eq(1)
+            yield top._transaction_data.w_data     .eq(0x100)
+            yield Tick()
+
+            # stop enqueueing ops
+            yield top._transaction_data.w_stb      .eq(0)
+            yield top._transaction_data.w_data     .eq(0)
+            yield Tick()
+
+            # start the i2c core
+            yield top._start.w_stb .eq(1)
+            yield top._start.w_data.eq(1)
+            yield Tick()
+
+            # run until it's done
+            for _ in range(600):
+                yield Tick()
+            assert (yield top._busy.r_data == 0)
+
+            # new device address
+            yield Tick()
+            yield top._address.w_stb               .eq(1)
+            yield top._address.w_data              .eq(0x07)
+
+            # enqueue 1x read op
+            yield top._transaction_data.w_stb      .eq(1)
+            yield top._transaction_data.w_data     .eq(0x100)
+            yield Tick()
+
+            # enqueue 1x write op
+            yield top._transaction_data.w_stb      .eq(1)
+            yield top._transaction_data.w_data     .eq(0x022)
+            yield Tick()
+
+            # start the i2c core
+            yield top._start.w_stb .eq(1)
+            yield top._start.w_data.eq(1)
+            yield Tick()
+
+            # run until it's done
+            for _ in range(600):
+                yield Tick()
+            assert (yield top._busy.r_data == 0)
+
+        sim = Simulator(top)
+        sim.add_clock(1e-6)
+        sim.add_process(testbench)
+        with sim.write_vcd(vcd_file=open("test_i2c_tx.vcd", "w")):
+            sim.run()

--- a/gateware/tests/test_i2c.py
+++ b/gateware/tests/test_i2c.py
@@ -2,7 +2,7 @@ import unittest
 
 from amaranth              import *
 from amaranth.sim          import *
-from vendor                import i2c
+from tiliqua               import i2c
 
 class I2CTests(unittest.TestCase):
 


### PR DESCRIPTION
Tiliqua R2 has a few I2C peripherals, so we need an I2C core that can be driven by the SoC. This one is largely based on the `transaction()` semantics from rust `embedded-hal` v1.0.0 - the exact semantics are added to the core documentation.