### PR TITLE
Improve video timings, set default to 1280x720p60

### DIFF
--- a/gateware/src/example_vectorscope/top.py
+++ b/gateware/src/example_vectorscope/top.py
@@ -8,7 +8,7 @@ Simple gateware-only version, see 'xbeam' for SoC version with a menu system.
 Rasterizes X/Y (audio channel 0, 1) and color (audio channel 3) to a simulated
 CRT display, with intensity gradient and afterglow effects.
 
-Default 800x600p60 seems to work with all the monitors I have, but other screens might
+Default 1280x720p60 seems to work with all the monitors I have, but other screens might
 need timing + PLL adjustments.
 
 There are top-level scripts for building/simulating e.g.
@@ -66,7 +66,7 @@ class VectorScopeTop(Elaboratable):
 
         # WARN: You have to modify the platform PLL if you change the pixel clock!
         # TODO: integrate ecp5_pll from lambdasoc or custom solution --
-        timings = DVI_TIMINGS["800x600p60"]
+        timings = DVI_TIMINGS["1280x720p60"]
         fb_base = 0x0
         fb_size = (timings.h_active, timings.v_active)
 

--- a/gateware/src/selftest/fw/src/main.rs
+++ b/gateware/src/selftest/fw/src/main.rs
@@ -36,8 +36,8 @@ use micromath::F32Ext;
 
 // TODO: fetch these from SVF
 const PSRAM_BASE:     usize = 0x20000000;
-const H_ACTIVE:       u32   = 800;
-const V_ACTIVE:       u32   = 600;
+const H_ACTIVE:       u32   = 1280;
+const V_ACTIVE:       u32   = 720;
 
 // 16MiB, 4 bytes per word.
 const PSRAM_SZ_WORDS: usize = 1024 * 1024 * (16 / 4); 

--- a/gateware/src/selftest/top.py
+++ b/gateware/src/selftest/top.py
@@ -165,5 +165,5 @@ if __name__ == "__main__":
     os.environ["AMARANTH_nextpnr_opts"] = "--timing-allow-fail"
     os.environ["AMARANTH_ecppack_opts"] = "--freq 38.8 --compress"
     os.environ["LUNA_PLATFORM"] = "tiliqua.tiliqua_platform:TiliquaPlatform"
-    design = SelfTestSoc(clock_frequency=int(60e6), dvi_timings=DVI_TIMINGS["800x600p60"])
+    design = SelfTestSoc(clock_frequency=int(60e6), dvi_timings=DVI_TIMINGS["1280x720p60"])
     top_level_cli(design)

--- a/gateware/src/tiliqua/raster.py
+++ b/gateware/src/tiliqua/raster.py
@@ -239,7 +239,7 @@ class Stroke(wiring.Component):
         m.submodules.split = split = dsp.Split(n_channels=4)
         m.submodules.merge = merge = dsp.Merge(n_channels=4)
 
-        N_UP=6
+        N_UP=4
         m.submodules.resample0 = resample0 = dsp.Resample(fs_in=192000, n_up=N_UP, m_down=1)
         m.submodules.resample1 = resample1 = dsp.Resample(fs_in=192000, n_up=N_UP, m_down=1)
         m.submodules.resample2 = resample2 = dsp.Resample(fs_in=192000, n_up=N_UP, m_down=1)

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -124,7 +124,7 @@ class _TiliquaPlatform(LatticeECP5Platform):
             Subsignal("d1", Pins("C5", dir="o")),
             Subsignal("d2", Pins("E4", dir="o")),
             Subsignal("ck", Pins("C6", dir="o")),
-            Attrs(IO_TYPE="LVCMOS33D", DRIVE="8", SLEWRATE="FAST")
+            Attrs(IO_TYPE="LVCMOS33D", DRIVE="4", SLEWRATE="SLOW")
          ),
     ]
 

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -124,7 +124,7 @@ class _TiliquaPlatform(LatticeECP5Platform):
             Subsignal("d1", Pins("C5", dir="o")),
             Subsignal("d2", Pins("E4", dir="o")),
             Subsignal("ck", Pins("C6", dir="o")),
-            Attrs(IO_TYPE="LVCMOS33D", DRIVE="4", SLEWRATE="SLOW")
+            Attrs(IO_TYPE="LVCMOS33D", DRIVE="8", SLEWRATE="FAST")
          ),
     ]
 

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -124,7 +124,7 @@ class _TiliquaPlatform(LatticeECP5Platform):
             Subsignal("d1", Pins("C5", dir="o")),
             Subsignal("d2", Pins("E4", dir="o")),
             Subsignal("ck", Pins("C6", dir="o")),
-            Attrs(IO_TYPE="LVCMOS33D", DRIVE="4")
+            Attrs(IO_TYPE="LVCMOS33D", DRIVE="8", SLEWRATE="FAST")
          ),
     ]
 
@@ -175,8 +175,6 @@ class TiliquaDomainGenerator(Elaboratable):
                 # Generated clock outputs.
                 o_CLKOP=feedback60,
                 o_CLKOS=ClockSignal("fast"),
-                o_CLKOS2=ClockSignal("dvi"),
-                o_CLKOS3=ClockSignal("dvi5x"),
 
                 # Status.
                 o_LOCK=locked60,
@@ -199,19 +197,79 @@ class TiliquaDomainGenerator(Elaboratable):
                 p_CLKOS_DIV=5,
                 p_CLKOS_CPHASE=4,
                 p_CLKOS_FPHASE=0,
-                p_CLKOS2_ENABLE="ENABLED",
-                p_CLKOS2_DIV=15,
-                p_CLKOS2_CPHASE=4,
-                p_CLKOS2_FPHASE=0,
-                p_CLKOS3_ENABLE="ENABLED",
-                p_CLKOS3_DIV=3,
-                p_CLKOS3_CPHASE=4,
-                p_CLKOS3_FPHASE=0,
                 p_FEEDBK_PATH="CLKOP",
                 p_CLKFB_DIV=5,
 
                 # Internal feedback.
                 i_CLKFB=feedback60,
+
+                # Control signals.
+                i_RST=reset,
+                i_PHASESEL0=0,
+                i_PHASESEL1=0,
+                i_PHASEDIR=1,
+                i_PHASESTEP=1,
+                i_PHASELOADREG=1,
+                i_STDBY=0,
+                i_PLLWAKESYNC=0,
+
+                # Output Enables.
+                i_ENCLKOP=0,
+                i_ENCLKOS=0,
+                i_ENCLKOS2=0,
+                i_ENCLKOS3=0,
+
+                # Synthesis attributes.
+                a_ICP_CURRENT="12",
+                a_LPF_RESISTOR="8"
+        )
+
+        # Extra PLL to generate 720p60 5x pixel clock (371.25MHz)
+        # CLKOP and CLKOS come from:
+        # ecppll -i 48 --clkout0 371.25 --highres --reset -f pll60.v
+        # CLKOS2 is manually added.
+        feedback_dvi = Signal()
+        locked_dvi   = Signal()
+        m.submodules.pll_dvi = Instance("EHXPLLL",
+
+                # Clock in.
+                i_CLKI=clk48,
+
+                # Generated clock outputs.
+                o_CLKOP=feedback_dvi,
+                o_CLKOS=ClockSignal("dvi5x"),
+                o_CLKOS2=ClockSignal("dvi"),
+
+                # Status.
+                o_LOCK=locked_dvi,
+
+                # PLL parameters...
+                p_PLLRST_ENA="ENABLED",
+                p_INTFB_WAKE="DISABLED",
+                p_STDBY_ENABLE="DISABLED",
+                p_DPHASE_SOURCE="DISABLED",
+                p_OUTDIVIDER_MUXA="DIVA",
+                p_OUTDIVIDER_MUXB="DIVB",
+                p_OUTDIVIDER_MUXC="DIVC",
+                p_OUTDIVIDER_MUXD="DIVD",
+                p_CLKI_DIV=15,
+                p_CLKOP_ENABLE="ENABLED",
+                p_CLKOP_DIV=58,
+                p_CLKOP_CPHASE=9,
+                p_CLKOP_FPHASE=0,
+                p_CLKOS_ENABLE="ENABLED",
+                p_CLKOS_DIV=2,
+                p_CLKOS_CPHASE=0,
+                p_CLKOS_FPHASE=0,
+                p_CLKOS2_ENABLE="ENABLED",
+                p_CLKOS2_DIV=10,
+                p_CLKOS2_CPHASE=0,
+                p_CLKOS2_FPHASE=0,
+                p_FEEDBK_PATH="CLKOP",
+                p_CLKFB_DIV=4,
+
+                # Internal feedback.
+                i_CLKFB=feedback_dvi,
 
                 # Control signals.
                 i_RST=reset,
@@ -369,8 +427,8 @@ class TiliquaDomainGenerator(Elaboratable):
             ResetSignal("sync")  .eq(~locked60),
             ResetSignal("fast")  .eq(~locked60),
             ResetSignal("usb")   .eq(~locked60),
-            ResetSignal("dvi")  .eq(~locked60),
-            ResetSignal("dvi5x").eq(~locked60),
+            ResetSignal("dvi")  .eq(~locked_dvi),
+            ResetSignal("dvi5x").eq(~locked_dvi),
 
             ResetSignal("audio")   .eq(~locked_audio),
         ]

--- a/gateware/src/tiliqua/video.py
+++ b/gateware/src/tiliqua/video.py
@@ -169,7 +169,7 @@ class FramebufferPHY(Elaboratable):
     """
 
     def __init__(self, *, dvi_timings: DVITimings, fb_base, bus_master,
-                 fb_size, fifo_depth=128, sim=False, fb_bytes_per_pixel=1):
+                 fb_size, fifo_depth=512, sim=False, fb_bytes_per_pixel=1):
 
         super().__init__()
 

--- a/gateware/src/xbeam/fw/src/main.rs
+++ b/gateware/src/xbeam/fw/src/main.rs
@@ -33,8 +33,8 @@ use tiliqua_lib::opt::*;
 
 // TODO: fetch these from SVF
 const PSRAM_BASE:     usize = 0x20000000;
-const H_ACTIVE:       u32   = 800;
-const V_ACTIVE:       u32   = 600;
+const H_ACTIVE:       u32   = 1280;
+const V_ACTIVE:       u32   = 720;
 
 // 16MiB, 4 bytes per word.
 const _PSRAM_SZ_WORDS: usize = 1024 * 1024 * (16 / 4); 

--- a/gateware/src/xbeam/top.py
+++ b/gateware/src/xbeam/top.py
@@ -244,5 +244,5 @@ if __name__ == "__main__":
     os.environ["AMARANTH_nextpnr_opts"] = "--timing-allow-fail"
     os.environ["AMARANTH_ecppack_opts"] = "--freq 38.8 --compress"
     os.environ["LUNA_PLATFORM"] = "tiliqua.tiliqua_platform:TiliquaPlatform"
-    design = XbeamSoc(clock_frequency=int(60e6), dvi_timings=DVI_TIMINGS["800x600p60"])
+    design = XbeamSoc(clock_frequency=int(60e6), dvi_timings=DVI_TIMINGS["1280x720p60"])
     top_level_cli(design)


### PR DESCRIPTION
* Rewrite timing generator to adhere to DVI spec
* Set default resolution to 1280x720p60
* Increase drive and slew, 8mA is still <10mA (spec) but we don't want to get too hot.
* Extra registers in TMDS serializer to improve timing