### PR TITLE
poly/xbeam: add color palette selection

### DIFF
--- a/gateware/src/poly/fw/Cargo.lock
+++ b/gateware/src/poly/fw/Cargo.lock
@@ -435,6 +435,7 @@ dependencies = [
  "embedded-graphics",
  "heapless",
  "log",
+ "micromath",
  "strum",
  "strum_macros 0.26.4",
 ]

--- a/gateware/src/poly/fw/src/lib.rs
+++ b/gateware/src/poly/fw/src/lib.rs
@@ -28,5 +28,9 @@ tiliqua_hal::impl_polysynth! {
     Polysynth0: pac::SYNTH_PERIPH,
 }
 
+tiliqua_hal::impl_video! {
+    Video0: pac::VIDEO_PERIPH,
+}
+
 pub mod handlers;
 pub mod opts;

--- a/gateware/src/poly/fw/src/opts.rs
+++ b/gateware/src/poly/fw/src/opts.rs
@@ -1,6 +1,7 @@
 use tiliqua_lib::opt::*;
 use tiliqua_lib::impl_option_view;
 use tiliqua_lib::impl_option_page;
+use tiliqua_lib::palette::ColorPalette;
 
 use heapless::String;
 
@@ -55,10 +56,11 @@ pub struct BeamOptions {
     pub decay: NumOption<u8>,
     pub intensity: NumOption<u8>,
     pub hue: NumOption<u8>,
+    pub palette: EnumOption<ColorPalette>,
 }
 
 impl_option_view!(BeamOptions,
-                  persist, decay, intensity, hue);
+                  persist, decay, intensity, hue, palette);
 
 #[derive(Clone)]
 pub struct Options {
@@ -140,6 +142,10 @@ impl Options {
                     step: 1,
                     min: 0,
                     max: 15,
+                },
+                palette: EnumOption {
+                    name: String::from_str("palette").unwrap(),
+                    value: ColorPalette::Exp,
                 },
             },
             vector: VectorOptions {

--- a/gateware/src/rs/hal/src/lib.rs
+++ b/gateware/src/rs/hal/src/lib.rs
@@ -11,6 +11,7 @@ pub mod encoder;
 pub mod pca9635;
 pub mod pmod;
 pub mod polysynth;
+pub mod video;
 
 pub use embedded_hal as hal;
 pub use embedded_hal_nb as hal_nb;

--- a/gateware/src/rs/hal/src/video.rs
+++ b/gateware/src/rs/hal/src/video.rs
@@ -1,0 +1,35 @@
+#[macro_export]
+macro_rules! impl_video {
+    ($(
+        $VIDEOX:ident: $PACVIDEOX:ty,
+    )+) => {
+        $(
+            #[derive(Debug)]
+            pub struct $VIDEOX {
+                registers: $PACVIDEOX,
+            }
+
+            impl $VIDEOX {
+                pub fn new(registers: $PACVIDEOX) -> Self {
+                    Self { registers }
+                }
+            }
+
+            impl $VIDEOX {
+                pub fn set_palette_rgb(&mut self, intensity: u32, hue: u32, r: u8, g: u8, b: u8)  {
+                    let reg: u32 = ((intensity & 0xF) << 28) | ((hue & 0xF) << 24) | ((r as u32) << 16) | ((g as u32) << 8) | b as u32;
+                    while self.registers.palette_busy().read().bits() == 1 { /* wait until last coeff written */ }
+                    self.registers.palette().write(|w| unsafe { w.palette().bits(reg) } );
+                }
+
+                pub fn set_persist(&mut self, value: u16)  {
+                    self.registers.persist().write(|w| unsafe { w.persist().bits(value) } );
+                }
+
+                pub fn set_decay(&mut self, value: u8)  {
+                    self.registers.decay().write(|w| unsafe { w.decay().bits(value) } );
+                }
+            }
+        )+
+    };
+}

--- a/gateware/src/rs/lib/Cargo.toml
+++ b/gateware/src/rs/lib/Cargo.toml
@@ -13,6 +13,7 @@ embedded-graphics = "0.8.1"
 heapless = "0.8.0"
 strum_macros = "0.26.4"
 strum = {version = "0.25.0", features = ["derive"], default-features=false}
+micromath = "2.1.0"
 
 [dev-dependencies]
 critical-section = { version = "1.1.2", features = ["std"] }

--- a/gateware/src/rs/lib/src/lib.rs
+++ b/gateware/src/rs/lib/src/lib.rs
@@ -4,3 +4,4 @@ pub mod opt;
 pub mod draw;
 pub mod log;
 pub mod generated_constants;
+pub mod palette;

--- a/gateware/src/rs/lib/src/palette.rs
+++ b/gateware/src/rs/lib/src/palette.rs
@@ -1,0 +1,91 @@
+use crate::generated_constants::*;
+
+use strum_macros::{EnumIter, IntoStaticStr};
+
+use micromath::F32Ext;
+
+#[derive(Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum ColorPalette {
+    Exp,
+    Linear,
+    Gray,
+    InvGray,
+}
+
+fn hue2rgb(p: f32, q: f32, mut t: f32) -> f32 {
+    if t < 0.0 {
+        t += 1.0;
+    }
+    if t > 1.0 {
+        t -= 1.0;
+    }
+    if t < 1.0 / 6.0 {
+        return p + (q - p) * 6.0 * t;
+    }
+    if t < 0.5 {
+        return q;
+    }
+    if t < 2.0 / 3.0 {
+        return p + (q - p) * (2.0 / 3.0 - t) * 6.0;
+    }
+    p
+}
+
+pub struct RGB {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+/// Converts an HSL color value to RGB. Conversion formula
+/// adapted from http://en.wikipedia.org/wiki/HSL_color_space.
+/// Assumes h, s, and l are contained in the set [0, 1] and
+/// returns RGB in the set [0, 255].
+pub fn hsl2rgb(h: f32, s: f32, l: f32) -> RGB {
+    if s == 0.0 {
+        // achromatic
+        let gray = (l * 255.0) as u8;
+        return RGB { r: gray, g: gray, b: gray };
+    }
+
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
+    let p = 2.0 * l - q;
+
+    RGB {
+        r: (hue2rgb(p, q, h + 1.0 / 3.0) * 255.0) as u8,
+        g: (hue2rgb(p, q, h) * 255.0) as u8,
+        b: (hue2rgb(p, q, h - 1.0 / 3.0) * 255.0) as u8,
+    }
+}
+
+pub fn compute_color(i: i32, h: i32, p: ColorPalette) -> RGB {
+    let n_i: i32 = PX_INTENSITY_MAX;
+    let n_h: i32 = PX_HUE_MAX;
+    match p {
+        ColorPalette::Exp => {
+            let fac = 1.35f32;
+            let hue = (h as f32)/(n_h as f32);
+            let saturation = 0.9f32;
+            let intensity = fac.powi(i+1) / fac.powi(n_i);
+            hsl2rgb(hue, saturation, intensity)
+        },
+        ColorPalette::Linear => {
+            hsl2rgb((h as f32)/(n_h as f32), 0.9f32,
+                    (i as f32)/(n_h as f32))
+        },
+        ColorPalette::Gray => {
+            let gray: u8 = (i * 16) as u8;
+            RGB { r: gray, g: gray, b: gray }
+        },
+        ColorPalette::InvGray => {
+            let gray: u8 = 255u8 - (i * 16) as u8;
+            RGB { r: gray, g: gray, b: gray }
+        }
+    }
+}
+

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -33,17 +33,18 @@ from luna_soc.gateware.csr.base                  import Peripheral
 
 TILIQUA_CLOCK_SYNC_HZ = int(60e6)
 
-class PersistPeripheral(Peripheral, Elaboratable):
+class VideoPeripheral(Peripheral, Elaboratable):
 
     """
     Tweak display persistance properties from SoC memory space.
     """
 
-    def __init__(self, fb_base, fb_size, bus):
+    def __init__(self, fb_base, fb_size, bus, video):
 
         super().__init__()
 
         self.en                = Signal()
+        self.video             = video
 
         self.persist = Persistance(
                 fb_base=fb_base, bus_master=bus.bus, fb_size=fb_size)
@@ -53,6 +54,12 @@ class PersistPeripheral(Peripheral, Elaboratable):
         bank                   = self.csr_bank()
         self._persist          = bank.csr(16, "w")
         self._decay            = bank.csr(8, "w")
+
+        # Palette coefficient write: 0xPPRRGGBB
+        # P = palette position (0..255), RGB = red, green, blue value displayed.
+        # Value is written ASAP, palette_busy will be set to 1 until it is complete.
+        self._palette           = bank.csr(32, "w")
+        self._palette_busy      = bank.csr(1,  "r")
 
         # Peripheral bus
         self._bridge    = self.bridge(data_width=32, granularity=8, alignment=2)
@@ -72,6 +79,25 @@ class PersistPeripheral(Peripheral, Elaboratable):
 
         with m.If(self._decay.w_stb):
             m.d.sync += self.persist.decay.eq(self._decay.w_data)
+
+        # palette update logic (TODO put this in subclass?)
+
+        palette_busy = Signal()
+        m.d.comb += self._palette_busy.r_data.eq(palette_busy)
+        with m.If(self._palette.w_stb & ~palette_busy):
+            m.d.sync += [
+                palette_busy.eq(1),
+                self.video.palette_rgb.payload.p  .eq(self._palette.w_data[24:32]),
+                self.video.palette_rgb.payload.rgb.eq(self._palette.w_data[ 0:24]),
+                self.video.palette_rgb.valid.eq(1),
+            ]
+
+        with m.If(palette_busy & self.video.palette_rgb.ready):
+            # coefficient has been written
+            m.d.sync += [
+                palette_busy.eq(0),
+                self.video.palette_rgb.valid.eq(0),
+            ]
 
         return m
 
@@ -148,11 +174,12 @@ class TiliquaSoc(Elaboratable):
         # ... add our video persistance effect (all writes gradually fade) -
         # this is an interesting alternative to double-buffering that looks
         # kind of like an old CRT with slow-scanning.
-        self.persist_periph = PersistPeripheral(
+        self.video_periph = VideoPeripheral(
             fb_base=self.video.fb_base,
             fb_size=fb_size,
-            bus=self.soc.psram)
-        self.soc.add_peripheral(self.persist_periph, addr=0xf0006000)
+            bus=self.soc.psram,
+            video=self.video)
+        self.soc.add_peripheral(self.video_periph, addr=0xf0006000)
 
         self.permit_bus_traffic = Signal()
 
@@ -183,7 +210,7 @@ class TiliquaSoc(Elaboratable):
         with m.Else():
             m.d.sync += self.permit_bus_traffic.eq(1)
             m.d.sync += self.video.enable.eq(1)
-            m.d.sync += self.persist_periph.en.eq(1)
+            m.d.sync += self.video_periph.en.eq(1)
 
         # generate our domain clocks/resets
         m.submodules.car = platform.clock_domain_generator(audio_192=self.audio_192,

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -259,3 +259,5 @@ class TiliquaSoc(Elaboratable):
             f.write(f"pub const V_ACTIVE: u32         = {self.video.fb_vsize};\n")
             f.write(f"pub const VIDEO_ROTATE_90: bool = {'true' if self.video_rotate_90 else 'false'};\n")
             f.write(f"pub const PSRAM_FB_BASE: usize  = 0x{self.video.fb_base:x};\n")
+            f.write(f"pub const PX_HUE_MAX: i32       = 16;\n")
+            f.write(f"pub const PX_INTENSITY_MAX: i32 = 16;\n")

--- a/gateware/src/tiliqua/video.py
+++ b/gateware/src/tiliqua/video.py
@@ -499,10 +499,11 @@ class FramebufferPHY(wiring.Component):
                   palette_b.write_port()]
         # split rgb payload into one write for each rgb memory
         m.d.comb += [
-            wports[0].data.eq(self.palette_rgb.payload.rgb[0 : 8]),
+            wports[0].data.eq(self.palette_rgb.payload.rgb[16:24]),
             wports[1].data.eq(self.palette_rgb.payload.rgb[8 :16]),
-            wports[2].data.eq(self.palette_rgb.payload.rgb[16:24]),
+            wports[2].data.eq(self.palette_rgb.payload.rgb[0 : 8]),
         ]
+        m.d.comb += self.palette_rgb.ready.eq(1)
         # hook up position and stream valid -> write enable.
         for wport in wports:
             with m.If(self.palette_rgb.ready):

--- a/gateware/src/tiliqua/video.py
+++ b/gateware/src/tiliqua/video.py
@@ -16,6 +16,8 @@ from amaranth.lib.cdc      import FFSynchronizer
 from amaranth.utils        import log2_int
 from amaranth.hdl.mem      import Memory
 
+from amaranth_future       import stream
+
 from luna_soc.gateware.vendor.amaranth_soc import wishbone
 
 from dataclasses import dataclass
@@ -245,7 +247,7 @@ class DVITimingGenerator(wiring.Component):
         return m
 
 
-class FramebufferPHY(Elaboratable):
+class FramebufferPHY(wiring.Component):
 
     """
     Read pixels from a framebuffer in PSRAM and send them to the display.
@@ -257,8 +259,6 @@ class FramebufferPHY(Elaboratable):
 
     def __init__(self, *, dvi_timings: DVITimings, fb_base, bus_master,
                  fb_size, fifo_depth=1024, sim=False, fb_bytes_per_pixel=1):
-
-        super().__init__()
 
         self.sim = sim
         self.fifo_depth = fifo_depth
@@ -286,6 +286,14 @@ class FramebufferPHY(Elaboratable):
         self.phy_r = Signal(8)
         self.phy_g = Signal(8)
         self.phy_b = Signal(8)
+
+        # Color palette tweaking interface
+        super().__init__({
+            "palette_rgb": In(stream.Signature(data.StructLayout({
+                "p": unsigned(8),
+                "rgb": unsigned(24),
+                }))),
+        })
 
     @staticmethod
     def compute_color_palette():
@@ -484,5 +492,23 @@ class FramebufferPHY(Elaboratable):
             phy_g.eq(rd_port_g.data),
             phy_b.eq(rd_port_b.data),
         ]
+
+        # palette write interface (p=position, rgb=value)
+        wports = [palette_r.write_port(),
+                  palette_g.write_port(),
+                  palette_b.write_port()]
+        # split rgb payload into one write for each rgb memory
+        m.d.comb += [
+            wports[0].data.eq(self.palette_rgb.payload.rgb[0 : 8]),
+            wports[1].data.eq(self.palette_rgb.payload.rgb[8 :16]),
+            wports[2].data.eq(self.palette_rgb.payload.rgb[16:24]),
+        ]
+        # hook up position and stream valid -> write enable.
+        for wport in wports:
+            with m.If(self.palette_rgb.ready):
+                m.d.comb += [
+                    wport.addr.eq(self.palette_rgb.payload.p),
+                    wport.en.eq(self.palette_rgb.valid),
+                ]
 
         return m

--- a/gateware/src/xbeam/fw/Cargo.lock
+++ b/gateware/src/xbeam/fw/Cargo.lock
@@ -36,6 +36,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "colorsys"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54261aba646433cb567ec89844be4c4825ca92a4f8afba52fc4dd88436e31bbd"
+
+[[package]]
 name = "critical-section"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +366,7 @@ dependencies = [
 name = "tiliqua-fw"
 version = "0.1.0"
 dependencies = [
+ "colorsys",
  "embedded-graphics",
  "embedded-hal 1.0.0",
  "fastrand",

--- a/gateware/src/xbeam/fw/Cargo.lock
+++ b/gateware/src/xbeam/fw/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "embedded-graphics",
  "heapless",
  "log",
+ "micromath",
  "strum",
  "strum_macros 0.26.4",
 ]

--- a/gateware/src/xbeam/fw/Cargo.toml
+++ b/gateware/src/xbeam/fw/Cargo.toml
@@ -19,3 +19,4 @@ fastrand = { version = "2.1.0", default-features = false }
 heapless = "0.8.0"
 strum_macros = "0.26.4"
 strum = {version = "0.25.0", features = ["derive"], default-features=false}
+colorsys = { version = "*", default-features = false }

--- a/gateware/src/xbeam/fw/src/lib.rs
+++ b/gateware/src/xbeam/fw/src/lib.rs
@@ -24,5 +24,9 @@ tiliqua_hal::impl_eurorack_pmod! {
     EurorackPmod0: pac::PMOD0_PERIPH,
 }
 
+tiliqua_hal::impl_video! {
+    Video0: pac::VIDEO_PERIPH,
+}
+
 pub mod handlers;
 pub mod opts;

--- a/gateware/src/xbeam/fw/src/main.rs
+++ b/gateware/src/xbeam/fw/src/main.rs
@@ -33,11 +33,63 @@ use tiliqua_lib::opt::*;
 
 use tiliqua_lib::generated_constants::*;
 
+use micromath::F32Ext;
+
 tiliqua_hal::impl_dma_display!(DMADisplay, H_ACTIVE, V_ACTIVE, VIDEO_ROTATE_90);
 
 const PCA9635_BAR_GREEN: [usize; 6] = [0, 2, 14, 12, 6, 4];
 const PCA9635_BAR_RED:   [usize; 6] = [1, 3, 15, 13, 7, 5];
 const _PCA9635_MIDI:     [usize; 2] = [8, 9];
+
+fn hue2rgb(p: f32, q: f32, mut t: f32) -> f32 {
+    if t < 0.0 {
+        t += 1.0;
+    }
+    if t > 1.0 {
+        t -= 1.0;
+    }
+    if t < 1.0 / 6.0 {
+        return p + (q - p) * 6.0 * t;
+    }
+    if t < 0.5 {
+        return q;
+    }
+    if t < 2.0 / 3.0 {
+        return p + (q - p) * (2.0 / 3.0 - t) * 6.0;
+    }
+    p
+}
+
+struct RGB {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+/// Converts an HSL color value to RGB. Conversion formula
+/// adapted from http://en.wikipedia.org/wiki/HSL_color_space.
+/// Assumes h, s, and l are contained in the set [0, 1] and
+/// returns RGB in the set [0, 255].
+fn hsl2rgb(h: f32, s: f32, l: f32) -> RGB {
+    if s == 0.0 {
+        // achromatic
+        let gray = (l * 255.0) as u8;
+        return RGB { r: gray, g: gray, b: gray };
+    }
+
+    let q = if l < 0.5 {
+        l * (1.0 + s)
+    } else {
+        l + s - l * s
+    };
+    let p = 2.0 * l - q;
+
+    RGB {
+        r: (hue2rgb(p, q, h + 1.0 / 3.0) * 255.0) as u8,
+        g: (hue2rgb(p, q, h) * 255.0) as u8,
+        b: (hue2rgb(p, q, h - 1.0 / 3.0) * 255.0) as u8,
+    }
+}
 
 #[entry]
 fn main() -> ! {
@@ -86,11 +138,17 @@ fn main() -> ! {
 
     let mut time_since_encoder_touched: u32 = 0;
 
-    for i in 0..16 {
-        for h in 0..16 {
-            // something grayscale
-            let rgb: u8 = (i*15) as u8;
-            video.set_palette_rgb(i, h, rgb, 0, 0);
+    let n_i = 16i32;
+    let n_h = 16i32;
+    for i in 0..n_i {
+        for h in 0..n_h {
+            //let rgb = hsl2rgb((h as f32)/16.0f32, 0.75f32, (i as f32)/16.0f32);
+            let fac = 1.35f32;
+            let hue = (h as f32)/(n_h as f32);
+            let saturation = 0.9f32;
+            let intensity = fac.powi(i+1) / fac.powi(n_i);
+            let rgb = hsl2rgb(hue, saturation, intensity);
+            video.set_palette_rgb(i as u32, h as u32, rgb.r, rgb.g, rgb.b);
         }
     }
 

--- a/gateware/src/xbeam/fw/src/main.rs
+++ b/gateware/src/xbeam/fw/src/main.rs
@@ -170,6 +170,8 @@ fn main() -> ! {
 
     let mut time_since_encoder_touched: u32 = 0;
 
+    // Write default palette setting
+    write_palette(&mut video, opts.beam.palette.value);
     let mut last_palette = opts.beam.palette.value;
 
     loop {

--- a/gateware/src/xbeam/fw/src/main.rs
+++ b/gateware/src/xbeam/fw/src/main.rs
@@ -11,6 +11,7 @@ use tiliqua_fw::Timer0;
 use tiliqua_fw::I2c0;
 use tiliqua_fw::Encoder0;
 use tiliqua_fw::EurorackPmod0;
+use tiliqua_fw::Video0;
 
 use log::info;
 
@@ -74,11 +75,12 @@ fn main() -> ! {
 
     let mut opts = opts::Options::new();
 
-    let persist = peripherals.PERSIST_PERIPH;
     let vscope  = peripherals.VECTOR_PERIPH;
     let scope  = peripherals.SCOPE_PERIPH;
 
     let mut pmod = EurorackPmod0::new(peripherals.PMOD0_PERIPH);
+
+    let mut video = Video0::new(peripherals.VIDEO_PERIPH);
 
     let mut toggle_encoder_leds = false;
 
@@ -117,8 +119,8 @@ fn main() -> ! {
             time_since_encoder_touched = 0;
         }
 
-        persist.persist().write(|w| unsafe { w.persist().bits(opts.beam.persist.value) } );
-        persist.decay().write(|w| unsafe { w.decay().bits(opts.beam.decay.value) } );
+        video.set_persist(opts.beam.persist.value);
+        video.set_decay(opts.beam.decay.value);
 
         vscope.hue().write(|w| unsafe { w.hue().bits(opts.beam.hue.value) } );
         vscope.intensity().write(|w| unsafe { w.intensity().bits(opts.beam.intensity.value) } );

--- a/gateware/src/xbeam/fw/src/main.rs
+++ b/gateware/src/xbeam/fw/src/main.rs
@@ -86,6 +86,14 @@ fn main() -> ! {
 
     let mut time_since_encoder_touched: u32 = 0;
 
+    for i in 0..16 {
+        for h in 0..16 {
+            // something grayscale
+            let rgb: u8 = (i*15) as u8;
+            video.set_palette_rgb(i, h, rgb, 0, 0);
+        }
+    }
+
     loop {
 
         if time_since_encoder_touched < 1000 || opts.modify() {

--- a/gateware/src/xbeam/fw/src/opts.rs
+++ b/gateware/src/xbeam/fw/src/opts.rs
@@ -33,6 +33,15 @@ pub struct VectorOptions {
 impl_option_view!(VectorOptions,
                   xscale, yscale);
 
+#[derive(Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum ColorPalette {
+    Exp,
+    Linear,
+    Gray,
+    InvGray,
+}
+
 #[derive(Clone)]
 pub struct BeamOptions {
     pub selected: Option<usize>,
@@ -40,10 +49,11 @@ pub struct BeamOptions {
     pub decay: NumOption<u8>,
     pub intensity: NumOption<u8>,
     pub hue: NumOption<u8>,
+    pub palette: EnumOption<ColorPalette>,
 }
 
 impl_option_view!(BeamOptions,
-                  persist, decay, intensity, hue);
+                  persist, decay, intensity, hue, palette);
 
 #[derive(Clone)]
 pub struct ScopeOptions {
@@ -133,6 +143,10 @@ impl Options {
                     step: 1,
                     min: 0,
                     max: 15,
+                },
+                palette: EnumOption {
+                    name: String::from_str("palette").unwrap(),
+                    value: ColorPalette::Exp,
                 },
             },
             scope: ScopeOptions {

--- a/gateware/src/xbeam/fw/src/opts.rs
+++ b/gateware/src/xbeam/fw/src/opts.rs
@@ -1,6 +1,7 @@
 use tiliqua_lib::opt::*;
 use tiliqua_lib::impl_option_view;
 use tiliqua_lib::impl_option_page;
+use tiliqua_lib::palette::ColorPalette;
 
 use heapless::String;
 
@@ -32,15 +33,6 @@ pub struct VectorOptions {
 
 impl_option_view!(VectorOptions,
                   xscale, yscale);
-
-#[derive(Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
-#[strum(serialize_all = "kebab-case")]
-pub enum ColorPalette {
-    Exp,
-    Linear,
-    Gray,
-    InvGray,
-}
 
 #[derive(Clone)]
 pub struct BeamOptions {


### PR DESCRIPTION
* expose palette memory that decodes pixels from RAM into screen colors
* allow the palette memory to be tweaked by the SoC
* add a menu option to change the palette to xbeam and poly
* start with linear, exponential, grayscale and inverted palettes