### PR TITLE
gateware/soc: modify vexriscv configuration, reduce fw size

### DIFF
--- a/gateware/src/boot/fw/Cargo.toml
+++ b/gateware/src/boot/fw/Cargo.toml
@@ -19,3 +19,12 @@ fastrand = { version = "2.1.0", default-features = false }
 heapless = "0.8.0"
 strum_macros = "0.26.4"
 strum = {version = "0.25.0", features = ["derive"], default-features=false}
+
+[profile.release]
+codegen-units = 1
+debug = true
+debug-assertions = false
+incremental = false
+lto = true
+opt-level = "s"
+overflow-checks = false

--- a/gateware/src/poly/fw/Cargo.toml
+++ b/gateware/src/poly/fw/Cargo.toml
@@ -20,3 +20,12 @@ heapless = "0.8.0"
 strum_macros = "0.26.4"
 strum = {version = "0.25.0", features = ["derive"], default-features=false}
 fixed = "1.28.0"
+
+[profile.release]
+codegen-units = 1
+debug = true
+debug-assertions = false
+incremental = false
+lto = true
+opt-level = "s"
+overflow-checks = false

--- a/gateware/src/poly/fw/src/main.rs
+++ b/gateware/src/poly/fw/src/main.rs
@@ -78,7 +78,7 @@ fn main() -> ! {
     let sysclk = pac::clock::sysclk();
     let mut timer = Timer0::new(peripherals.TIMER0, sysclk);
 
-    info!("Hello from Tiliqua XBEAM!");
+    info!("Hello from Tiliqua POLY!");
 
     let i2cdev = I2c0::new(peripherals.I2C0);
 

--- a/gateware/src/rs/handlers.rs
+++ b/gateware/src/rs/handlers.rs
@@ -37,12 +37,6 @@ pub fn logger_init(writer: Serial0) {
     }
 }
 
-#[riscv_rt::pre_init]
-unsafe fn pre_main() {
-    pac::cpu::vexriscv::flush_icache();
-    pac::cpu::vexriscv::flush_dcache();
-}
-
 #[cfg(not(test))]
 #[panic_handler]
 fn panic(panic_info: &PanicInfo) -> ! {

--- a/gateware/src/selftest/fw/Cargo.toml
+++ b/gateware/src/selftest/fw/Cargo.toml
@@ -19,3 +19,12 @@ fastrand = { version = "2.1.0", default-features = false }
 heapless = "0.8.0"
 strum_macros = "0.26.4"
 strum = {version = "0.25.0", features = ["derive"], default-features=false}
+
+[profile.release]
+codegen-units = 1
+debug = true
+debug-assertions = false
+incremental = false
+lto = true
+opt-level = "s"
+overflow-checks = false

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -125,7 +125,7 @@ class TiliquaSoc(Component):
         self.clock_sync_hz = TILIQUA_CLOCK_SYNC_HZ
 
         self.mainram_base         = 0x00000000
-        self.mainram_size         = 0x00010000  # 65536 bytes
+        self.mainram_size         = 0x00008000
         self.psram_base           = 0x20000000
         self.psram_size           = 16*1024*1024
         self.csr_base             = 0xf0000000

--- a/gateware/src/tiliqua/video.py
+++ b/gateware/src/tiliqua/video.py
@@ -256,7 +256,7 @@ class FramebufferPHY(wiring.Component):
     """
 
     def __init__(self, *, dvi_timings: DVITimings, fb_base, bus_master,
-                 fb_size, fifo_depth=1024, sim=False, fb_bytes_per_pixel=1):
+                 fb_size, fifo_depth=256, sim=False, fb_bytes_per_pixel=1):
 
         self.sim = sim
         self.fifo_depth = fifo_depth

--- a/gateware/src/vendor/soc/cpu/verilog/vexriscv/scala/build.sbt
+++ b/gateware/src/vendor/soc/cpu/verilog/vexriscv/scala/build.sbt
@@ -1,4 +1,4 @@
-val spinalVersion = "1.6.0"
+val spinalVersion = "1.10.2a"
 
 lazy val vexRiscv = RootProject(uri("https://github.com/SpinalHDL/VexRiscv.git#master"))
 
@@ -6,12 +6,14 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.github.spinalhdl",
-      scalaVersion := "2.11.12",
-      version      := "0.1.0-SNAPSHOT"
+      scalaVersion := "2.12.18",
+      version      := "2.0.0"
     )),
     name := "VexRiscvOnWishbone",
     libraryDependencies ++= Seq(
-        compilerPlugin("com.github.spinalhdl" % "spinalhdl-idsl-plugin_2.11" % spinalVersion)
+        "com.github.spinalhdl" %% "spinalhdl-core" % spinalVersion,
+        "com.github.spinalhdl" %% "spinalhdl-lib" % spinalVersion,
+        compilerPlugin("com.github.spinalhdl" %% "spinalhdl-idsl-plugin" % spinalVersion)
     ),
     scalacOptions += s"-Xplugin-require:idsl-plugin"
   ).dependsOn(vexRiscv)

--- a/gateware/src/vendor/soc/cpu/verilog/vexriscv/scala/src/main/scala/GenCoreCynthion.scala
+++ b/gateware/src/vendor/soc/cpu/verilog/vexriscv/scala/src/main/scala/GenCoreCynthion.scala
@@ -26,25 +26,13 @@ object GenCoreCynthion {
       // configure plugins
       val plugins = ArrayBuffer[Plugin[VexRiscv]]()
       plugins ++= List(
-        new IBusCachedPlugin(
+        new IBusSimplePlugin(
           resetVector = null,
-          relaxedPcCalculation = false,
           prediction = STATIC,
-          compressedGen = true, // compressed instruction support
-          memoryTranslatorPortConfig = null,
-          config = InstructionCacheConfig(
-            cacheSize = 2048,
-            bytePerLine = 32,
-            wayCount = 1,
-            addressWidth = 32,
-            cpuDataWidth = 32,
-            memDataWidth = 32,
-            catchIllegalAccess = true,
-            catchAccessFault = true,
-            asyncTagMemory = false,
-            twoCycleRam = false,
-            twoCycleCache = false // !compressedGen
-          )
+          cmdForkOnSecondStage = false,
+          cmdForkPersistence = false, //Not required as the wishbone bridge ensure it
+          compressedGen = true,
+          memoryTranslatorPortConfig = null
         ),
         new DBusCachedPlugin(
           dBusCmdMasterPipe = true,
@@ -52,7 +40,7 @@ object GenCoreCynthion {
           dBusRspSlavePipe = false,
           relaxedMemoryTranslationRegister = false,
           config = new DataCacheConfig(
-            cacheSize = 4096,
+            cacheSize = 1024,
             bytePerLine = 32,
             wayCount = 1,
             addressWidth = 32,

--- a/gateware/src/vendor/soc/cpu/verilog/vexriscv/vexriscv_cynthion.v
+++ b/gateware/src/vendor/soc/cpu/verilog/vexriscv/vexriscv_cynthion.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.10.1    git head : 2527c7c6b0fb0f95e5e1a5722a0be732b364ce43
+// Generator : SpinalHDL v1.10.2a    git head : a348a60b7e8b6a455c72e1536ec3d74a2ea16935
 // Component : VexRiscv
-// Git hash  : 2537451497679e09618c8a57acf7b36b01b974f4
+// Git hash  : fc66e9abeed6e890ecb698f989aa779fe0895bce
 
 `timescale 1ns/1ps
 
@@ -96,8 +96,8 @@ module VexRiscv (
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
   wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
-  reg        [31:0]   _zz_RegFilePlugin_regFile_port0;
-  reg        [31:0]   _zz_RegFilePlugin_regFile_port1;
+  reg        [31:0]   RegFilePlugin_regFile_spinal_port0;
+  reg        [31:0]   RegFilePlugin_regFile_spinal_port1;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_error;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling;
@@ -433,7 +433,7 @@ module VexRiscv (
   wire       [31:0]   execute_MEMORY_STORE_DATA_RF;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_PREDICTION_HAD_BRANCHED1;
   wire                decode_SRC2_FORCE_ZERO;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
@@ -511,7 +511,7 @@ module VexRiscv (
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_BRANCH_COND_RESULT;
-  wire                execute_PREDICTION_HAD_BRANCHED2;
+  wire                execute_PREDICTION_HAD_BRANCHED1;
   wire       [1:0]    execute_BRANCH_CTRL;
   wire       [1:0]    _zz_execute_BRANCH_CTRL;
   wire                decode_RS2_USE;
@@ -942,7 +942,7 @@ module VexRiscv (
   reg        [3:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
   reg        [2:0]    toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_size;
   reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_last;
-  wire                when_Stream_l369;
+  wire                when_Stream_l375;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire                when_DBusCachedPlugin_l353;
   wire                when_DBusCachedPlugin_l361;
@@ -1295,7 +1295,7 @@ module VexRiscv (
   wire                when_Pipeline_l124_50;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
   wire                when_Pipeline_l124_51;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED1;
   wire                when_Pipeline_l124_52;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
   wire                when_Pipeline_l124_53;
@@ -1412,8 +1412,10 @@ module VexRiscv (
   wire                when_CsrPlugin_l1725;
   reg        [2:0]    _zz_iBusWishbone_ADR;
   wire                when_InstructionCache_l239;
+  wire                when_InstructionCache_l242;
   reg                 _zz_iBus_rsp_valid;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
+  reg                 iBusWishbone_ERR_regNext;
   reg        [2:0]    _zz_dBusWishbone_ADR;
   wire                _zz_dBusWishbone_CYC;
   wire                _zz_dBus_cmd_ready;
@@ -1422,6 +1424,7 @@ module VexRiscv (
   wire                _zz_dBusWishbone_ADR_1;
   reg                 _zz_dBus_rsp_valid;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
+  reg                 dBusWishbone_ERR_regNext;
   `ifndef SYNTHESIS
   reg [47:0] _zz_memory_to_writeBack_ENV_CTRL_string;
   reg [47:0] _zz_memory_to_writeBack_ENV_CTRL_1_string;
@@ -1507,7 +1510,7 @@ module VexRiscv (
 
   assign _zz_when = (|{decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid});
   assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
-  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0000000000000) + $signed(_zz_memory_MUL_LOW_2));
+  assign _zz_memory_MUL_LOW_1 = ($signed(52'h0) + $signed(_zz_memory_MUL_LOW_2));
   assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
   assign _zz_memory_MUL_LOW_2 = {{19{_zz_memory_MUL_LOW_3[32]}}, _zz_memory_MUL_LOW_3};
   assign _zz_memory_MUL_LOW_5 = ({16'd0,memory_MUL_LH} <<< 5'd16);
@@ -1524,7 +1527,7 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
   assign _zz_IBusCachedPlugin_decodePc_pcPlus_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
   assign _zz_IBusCachedPlugin_decodePc_pcPlus = {29'd0, _zz_IBusCachedPlugin_decodePc_pcPlus_1};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_30 = {{_zz_IBusCachedPlugin_decompressor_decompressed_10,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},12'h000};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_30 = {{_zz_IBusCachedPlugin_decompressor_decompressed_10,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},12'h0};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_37 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_38 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
   assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
@@ -1544,7 +1547,7 @@ module VexRiscv (
   assign _zz_execute_SrcPlugin_addSub_1 = ($signed(_zz_execute_SrcPlugin_addSub_2) + $signed(_zz_execute_SrcPlugin_addSub_3));
   assign _zz_execute_SrcPlugin_addSub_2 = execute_SRC1;
   assign _zz_execute_SrcPlugin_addSub_3 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h00000000);
+  assign _zz_execute_SrcPlugin_addSub_4 = (execute_SRC_USE_SUB_LESS ? 32'h00000001 : 32'h0);
   assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz_execute_BranchPlugin_branch_src2_11 = (execute_IS_RVC ? 3'b010 : 3'b100);
@@ -1603,7 +1606,7 @@ module VexRiscv (
   assign _zz_IBusCachedPlugin_decompressor_decompressed_29 = _zz_IBusCachedPlugin_decompressor_decompressed[2];
   assign _zz_IBusCachedPlugin_decompressor_decompressed_31 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b01);
   assign _zz_IBusCachedPlugin_decompressor_decompressed_32 = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b11) && (_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5] == 2'b00));
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_33 = 7'h00;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_33 = 7'h0;
   assign _zz_IBusCachedPlugin_decompressor_decompressed_34 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2];
   assign _zz_IBusCachedPlugin_decompressor_decompressed_35 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
   assign _zz_IBusCachedPlugin_decompressor_decompressed_36 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 7];
@@ -1733,7 +1736,7 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_113 = {_zz__zz_decode_IS_RS2_SIGNED_114,{_zz__zz_decode_IS_RS2_SIGNED_115,_zz__zz_decode_IS_RS2_SIGNED_116}};
   assign _zz__zz_decode_IS_RS2_SIGNED_122 = (decode_INSTRUCTION & 32'h00000070);
   assign _zz__zz_decode_IS_RS2_SIGNED_123 = 32'h00000020;
-  assign _zz__zz_decode_IS_RS2_SIGNED_126 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_127) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_126 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_127) == 32'h0);
   assign _zz__zz_decode_IS_RS2_SIGNED_130 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_131) == 32'h00004010);
   assign _zz__zz_decode_IS_RS2_SIGNED_133 = (_zz__zz_decode_IS_RS2_SIGNED_134 == _zz__zz_decode_IS_RS2_SIGNED_135);
   assign _zz__zz_decode_IS_RS2_SIGNED_137 = (|{_zz__zz_decode_IS_RS2_SIGNED_138,_zz__zz_decode_IS_RS2_SIGNED_140});
@@ -1746,12 +1749,12 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_112 = 32'h00002008;
   assign _zz__zz_decode_IS_RS2_SIGNED_114 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
   assign _zz__zz_decode_IS_RS2_SIGNED_115 = _zz_decode_IS_RS2_SIGNED_6;
-  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_117) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_116 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_117) == 32'h0);
   assign _zz__zz_decode_IS_RS2_SIGNED_127 = 32'h00000020;
   assign _zz__zz_decode_IS_RS2_SIGNED_131 = 32'h00004014;
   assign _zz__zz_decode_IS_RS2_SIGNED_134 = (decode_INSTRUCTION & 32'h00006014);
   assign _zz__zz_decode_IS_RS2_SIGNED_135 = 32'h00002010;
-  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_139) == 32'h00000000);
+  assign _zz__zz_decode_IS_RS2_SIGNED_138 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_139) == 32'h0);
   assign _zz__zz_decode_IS_RS2_SIGNED_140 = {_zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_141,{_zz__zz_decode_IS_RS2_SIGNED_142,_zz__zz_decode_IS_RS2_SIGNED_144}}};
   assign _zz__zz_decode_IS_RS2_SIGNED_148 = {_zz_decode_IS_RS2_SIGNED_3,(_zz__zz_decode_IS_RS2_SIGNED_149 == _zz__zz_decode_IS_RS2_SIGNED_150)};
   assign _zz__zz_decode_IS_RS2_SIGNED_152 = (|{_zz__zz_decode_IS_RS2_SIGNED_153,{_zz__zz_decode_IS_RS2_SIGNED_154,_zz__zz_decode_IS_RS2_SIGNED_156}});
@@ -1763,7 +1766,7 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_142 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_143) == 32'h00001000);
   assign _zz__zz_decode_IS_RS2_SIGNED_144 = {(_zz__zz_decode_IS_RS2_SIGNED_145 == _zz__zz_decode_IS_RS2_SIGNED_146),_zz_decode_IS_RS2_SIGNED_3};
   assign _zz__zz_decode_IS_RS2_SIGNED_149 = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz__zz_decode_IS_RS2_SIGNED_150 = 32'h00000000;
+  assign _zz__zz_decode_IS_RS2_SIGNED_150 = 32'h0;
   assign _zz__zz_decode_IS_RS2_SIGNED_153 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
   assign _zz__zz_decode_IS_RS2_SIGNED_154 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_155) == 32'h00002010);
   assign _zz__zz_decode_IS_RS2_SIGNED_156 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_157) == 32'h40000030);
@@ -1786,16 +1789,16 @@ module VexRiscv (
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[20];
   assign _zz_execute_BranchPlugin_branch_src2_9 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_10 = execute_INSTRUCTION[7];
-  assign _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h00000000;
+  assign _zz_CsrPlugin_csrMapping_readDataInit_24 = 32'h0;
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs1Data) begin
-      _zz_RegFilePlugin_regFile_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+      RegFilePlugin_regFile_spinal_port0 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @(posedge clk) begin
     if(_zz_decode_RegFilePlugin_rs2Data) begin
-      _zz_RegFilePlugin_regFile_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+      RegFilePlugin_regFile_spinal_port1 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
@@ -2655,14 +2658,14 @@ module VexRiscv (
   assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
   assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED1 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_SHIFT_RIGHT = _zz_execute_SHIFT_RIGHT;
   assign execute_REGFILE_WRITE_DATA = _zz_execute_REGFILE_WRITE_DATA;
   assign memory_MEMORY_STORE_DATA_RF = execute_to_memory_MEMORY_STORE_DATA_RF;
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h00)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h00))));
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED1 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[34];
   assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[33];
@@ -2721,7 +2724,7 @@ module VexRiscv (
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
-  assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  assign execute_PREDICTION_HAD_BRANCHED1 = decode_to_execute_PREDICTION_HAD_BRANCHED1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
   assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[17];
   assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
@@ -3309,12 +3312,12 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != 2'b11);
   assign _zz_IBusCachedPlugin_decompressor_decompressed = IBusCachedPlugin_decompressor_raw[15 : 0];
   always @(*) begin
-    IBusCachedPlugin_decompressor_decompressed = 32'h00000000;
+    IBusCachedPlugin_decompressor_decompressed = 32'h0;
     case(switch_Misc_l44)
-      5'h00 : begin
+      5'h0 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_IBusCachedPlugin_decompressor_decompressed[10 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 11]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00},5'h02},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h13};
         if(when_Misc_l47) begin
-          IBusCachedPlugin_decompressor_decompressed = 32'h00000000;
+          IBusCachedPlugin_decompressor_decompressed = 32'h0;
         end
       end
       5'h02 : begin
@@ -3330,13 +3333,13 @@ module VexRiscv (
         IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_8[20],_zz_IBusCachedPlugin_decompressor_decompressed_8[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_8[11]},_zz_IBusCachedPlugin_decompressor_decompressed_8[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_20},7'h6f};
       end
       5'h0a : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,5'h00},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,5'h0},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h0b : begin
         IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7] == 5'h02) ? {{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_27,_zz_IBusCachedPlugin_decompressor_decompressed_28},_zz_IBusCachedPlugin_decompressor_decompressed_29},_zz_IBusCachedPlugin_decompressor_decompressed[6]},4'b0000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13} : {{_zz_IBusCachedPlugin_decompressor_decompressed_30[31 : 12],_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h37});
       end
       5'h0c : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusCachedPlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusCachedPlugin_decompressor_decompressed_31 || _zz_IBusCachedPlugin_decompressor_decompressed_32)},5'h00}),(((! _zz_IBusCachedPlugin_decompressor_decompressed[11]) || _zz_IBusCachedPlugin_decompressor_decompressed_22) ? _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] : _zz_IBusCachedPlugin_decompressor_decompressed_2)},_zz_IBusCachedPlugin_decompressor_decompressed_1},_zz_IBusCachedPlugin_decompressor_decompressed_24},_zz_IBusCachedPlugin_decompressor_decompressed_1},(_zz_IBusCachedPlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusCachedPlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusCachedPlugin_decompressor_decompressed_31 || _zz_IBusCachedPlugin_decompressor_decompressed_32)},5'h0}),(((! _zz_IBusCachedPlugin_decompressor_decompressed[11]) || _zz_IBusCachedPlugin_decompressor_decompressed_22) ? _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] : _zz_IBusCachedPlugin_decompressor_decompressed_2)},_zz_IBusCachedPlugin_decompressor_decompressed_1},_zz_IBusCachedPlugin_decompressor_decompressed_24},_zz_IBusCachedPlugin_decompressor_decompressed_1},(_zz_IBusCachedPlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
       end
       5'h0d : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_15[20],_zz_IBusCachedPlugin_decompressor_decompressed_15[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_15[11]},_zz_IBusCachedPlugin_decompressor_decompressed_15[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_19},7'h6f};
@@ -3348,13 +3351,13 @@ module VexRiscv (
         IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_18[12],_zz_IBusCachedPlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed_19},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_18[11]},7'h63};
       end
       5'h10 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h00,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
+        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h12 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[3 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[12]},_zz_IBusCachedPlugin_decompressor_decompressed[6 : 4]},2'b00},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h03};
       end
       5'h14 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] == 5'h00) ? {{{{12'h000,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusCachedPlugin_decompressor_decompressed[12] ? _zz_IBusCachedPlugin_decompressor_decompressed_20 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_33,_zz_IBusCachedPlugin_decompressor_decompressed_34},(_zz_IBusCachedPlugin_decompressor_decompressed_35 ? _zz_IBusCachedPlugin_decompressor_decompressed_36 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h33}));
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] == 5'h0) ? {{{{12'h0,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusCachedPlugin_decompressor_decompressed[12] ? _zz_IBusCachedPlugin_decompressor_decompressed_20 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_33,_zz_IBusCachedPlugin_decompressor_decompressed_34},(_zz_IBusCachedPlugin_decompressor_decompressed_35 ? _zz_IBusCachedPlugin_decompressor_decompressed_36 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h33}));
       end
       5'h16 : begin
         IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_37[11 : 5],_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_38[4 : 0]},7'h23};
@@ -3366,7 +3369,7 @@ module VexRiscv (
 
   assign _zz_IBusCachedPlugin_decompressor_decompressed_1 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[9 : 7]};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_2 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 2]};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_3 = {{{{5'h00,_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00};
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_3 = {{{{5'h0,_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00};
   assign _zz_IBusCachedPlugin_decompressor_decompressed_4 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
   always @(*) begin
     _zz_IBusCachedPlugin_decompressor_decompressed_5[11] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
@@ -3445,11 +3448,11 @@ module VexRiscv (
   end
 
   assign _zz_IBusCachedPlugin_decompressor_decompressed_18 = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_17,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},1'b0};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_19 = 5'h00;
+  assign _zz_IBusCachedPlugin_decompressor_decompressed_19 = 5'h0;
   assign _zz_IBusCachedPlugin_decompressor_decompressed_20 = 5'h01;
   assign _zz_IBusCachedPlugin_decompressor_decompressed_21 = 5'h02;
   assign switch_Misc_l44 = {_zz_IBusCachedPlugin_decompressor_decompressed[1 : 0],_zz_IBusCachedPlugin_decompressor_decompressed[15 : 13]};
-  assign when_Misc_l47 = (_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h000);
+  assign when_Misc_l47 = (_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h0);
   assign _zz_IBusCachedPlugin_decompressor_decompressed_22 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] != 2'b11);
   assign switch_Misc_l241 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 10];
   assign switch_Misc_l241_1 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 5];
@@ -3671,12 +3674,12 @@ module VexRiscv (
   assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_last = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_last : toplevel_dataCache_1_io_mem_cmd_rData_last);
   always @(*) begin
     toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
-    if(when_Stream_l369) begin
+    if(when_Stream_l375) begin
       toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready = 1'b1;
     end
   end
 
-  assign when_Stream_l369 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
+  assign when_Stream_l375 = (! toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid);
   assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid;
   assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
   assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = toplevel_dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
@@ -3726,7 +3729,7 @@ module VexRiscv (
   end
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h00);
+  assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
   assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
   assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
   assign when_DBusCachedPlugin_l395 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
@@ -3918,11 +3921,11 @@ module VexRiscv (
   assign _zz_decode_IS_RS2_SIGNED_1 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
   assign _zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
   assign _zz_decode_IS_RS2_SIGNED_3 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h00000000);
+  assign _zz_decode_IS_RS2_SIGNED_4 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
   assign _zz_decode_IS_RS2_SIGNED_5 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_6 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
   assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00000000);
+  assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
   assign _zz_decode_IS_RS2_SIGNED = {(|_zz_decode_IS_RS2_SIGNED_8),{(|_zz_decode_IS_RS2_SIGNED_8),{(|(_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1)),{(|_zz__zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_3),{_zz__zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_9,_zz__zz_decode_IS_RS2_SIGNED_12}}}}}}};
   assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
@@ -3941,11 +3944,11 @@ module VexRiscv (
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
-  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h00);
+  assign when_RegFilePlugin_l63 = (decode_INSTRUCTION[11 : 7] == 5'h0);
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_RegFilePlugin_regFile_port0;
-  assign decode_RegFilePlugin_rs2Data = _zz_RegFilePlugin_regFile_port1;
+  assign decode_RegFilePlugin_rs1Data = RegFilePlugin_regFile_spinal_port0;
+  assign decode_RegFilePlugin_rs2Data = RegFilePlugin_regFile_spinal_port1;
   always @(*) begin
     lastStageRegFileWrite_valid = (_zz_lastStageRegFileWrite_valid && writeBack_arbitration_isFiring);
     if(_zz_5) begin
@@ -3956,14 +3959,14 @@ module VexRiscv (
   always @(*) begin
     lastStageRegFileWrite_payload_address = _zz_lastStageRegFileWrite_payload_address[11 : 7];
     if(_zz_5) begin
-      lastStageRegFileWrite_payload_address = 5'h00;
+      lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
   always @(*) begin
     lastStageRegFileWrite_payload_data = _zz_decode_RS2_2;
     if(_zz_5) begin
-      lastStageRegFileWrite_payload_data = 32'h00000000;
+      lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
 
@@ -4004,7 +4007,7 @@ module VexRiscv (
         _zz_execute_SRC1 = {29'd0, _zz__zz_execute_SRC1};
       end
       Src1CtrlEnum_IMU : begin
-        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h000};
+        _zz_execute_SRC1 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
         _zz_execute_SRC1 = {27'd0, _zz__zz_execute_SRC1_1};
@@ -4319,7 +4322,7 @@ module VexRiscv (
       end
       default : begin
         execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_execute_BranchPlugin_branch_src2_3,{{{_zz_execute_BranchPlugin_branch_src2_6,_zz_execute_BranchPlugin_branch_src2_7},_zz_execute_BranchPlugin_branch_src2_8},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_execute_BranchPlugin_branch_src2_5,{{{_zz_execute_BranchPlugin_branch_src2_9,_zz_execute_BranchPlugin_branch_src2_10},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2) begin
+        if(execute_PREDICTION_HAD_BRANCHED1) begin
           execute_BranchPlugin_branch_src2 = {29'd0, _zz_execute_BranchPlugin_branch_src2_11};
         end
       end
@@ -4747,12 +4750,12 @@ module VexRiscv (
   assign memory_DivPlugin_div_counter_willOverflow = (memory_DivPlugin_div_counter_willOverflowIfInc && memory_DivPlugin_div_counter_willIncrement);
   always @(*) begin
     if(memory_DivPlugin_div_counter_willOverflow) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h00;
+      memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
       memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_memory_DivPlugin_div_counter_valueNext);
     end
     if(memory_DivPlugin_div_counter_willClear) begin
-      memory_DivPlugin_div_counter_valueNext = 6'h00;
+      memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
@@ -4923,7 +4926,7 @@ module VexRiscv (
   assign when_CsrPlugin_l1669_22 = (! execute_arbitration_isStuck);
   assign when_CsrPlugin_l1669_23 = (! execute_arbitration_isStuck);
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
       _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
       _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
@@ -4931,28 +4934,28 @@ module VexRiscv (
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_2 = 32'h0;
     if(execute_CsrPlugin_csr_3857) begin
       _zz_CsrPlugin_csrMapping_readDataInit_2[3 : 0] = 4'b1011;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_3 = 32'h0;
     if(execute_CsrPlugin_csr_3858) begin
       _zz_CsrPlugin_csrMapping_readDataInit_3[4 : 0] = 5'h16;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_4 = 32'h0;
     if(execute_CsrPlugin_csr_3859) begin
       _zz_CsrPlugin_csrMapping_readDataInit_4[5 : 0] = 6'h21;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_5 = 32'h0;
     if(execute_CsrPlugin_csr_769) begin
       _zz_CsrPlugin_csrMapping_readDataInit_5[31 : 30] = CsrPlugin_misa_base;
       _zz_CsrPlugin_csrMapping_readDataInit_5[25 : 0] = CsrPlugin_misa_extensions;
@@ -4961,7 +4964,7 @@ module VexRiscv (
 
   assign switch_CsrPlugin_l1031 = CsrPlugin_csrMapping_writeDataSignal[12 : 11];
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_6 = 32'h0;
     if(execute_CsrPlugin_csr_768) begin
       _zz_CsrPlugin_csrMapping_readDataInit_6[7 : 7] = CsrPlugin_mstatus_MPIE;
       _zz_CsrPlugin_csrMapping_readDataInit_6[3 : 3] = CsrPlugin_mstatus_MIE;
@@ -4970,7 +4973,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_7 = 32'h0;
     if(execute_CsrPlugin_csr_836) begin
       _zz_CsrPlugin_csrMapping_readDataInit_7[11 : 11] = CsrPlugin_mip_MEIP;
       _zz_CsrPlugin_csrMapping_readDataInit_7[7 : 7] = CsrPlugin_mip_MTIP;
@@ -4979,7 +4982,7 @@ module VexRiscv (
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_8 = 32'h0;
     if(execute_CsrPlugin_csr_772) begin
       _zz_CsrPlugin_csrMapping_readDataInit_8[11 : 11] = CsrPlugin_mie_MEIE;
       _zz_CsrPlugin_csrMapping_readDataInit_8[7 : 7] = CsrPlugin_mie_MTIE;
@@ -4988,28 +4991,28 @@ module VexRiscv (
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_9 = 32'h0;
     if(execute_CsrPlugin_csr_773) begin
       _zz_CsrPlugin_csrMapping_readDataInit_9[31 : 2] = CsrPlugin_mtvec_base;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_10 = 32'h0;
     if(execute_CsrPlugin_csr_833) begin
       _zz_CsrPlugin_csrMapping_readDataInit_10[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_11 = 32'h0;
     if(execute_CsrPlugin_csr_832) begin
       _zz_CsrPlugin_csrMapping_readDataInit_11[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_12 = 32'h0;
     if(execute_CsrPlugin_csr_834) begin
       _zz_CsrPlugin_csrMapping_readDataInit_12[31 : 31] = CsrPlugin_mcause_interrupt;
       _zz_CsrPlugin_csrMapping_readDataInit_12[3 : 0] = CsrPlugin_mcause_exceptionCode;
@@ -5017,77 +5020,77 @@ module VexRiscv (
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_13 = 32'h0;
     if(execute_CsrPlugin_csr_835) begin
       _zz_CsrPlugin_csrMapping_readDataInit_13[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_14 = 32'h0;
     if(execute_CsrPlugin_csr_2816) begin
       _zz_CsrPlugin_csrMapping_readDataInit_14[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_15 = 32'h0;
     if(execute_CsrPlugin_csr_2944) begin
       _zz_CsrPlugin_csrMapping_readDataInit_15[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_16 = 32'h0;
     if(execute_CsrPlugin_csr_2818) begin
       _zz_CsrPlugin_csrMapping_readDataInit_16[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_17 = 32'h0;
     if(execute_CsrPlugin_csr_2946) begin
       _zz_CsrPlugin_csrMapping_readDataInit_17[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_18 = 32'h0;
     if(execute_CsrPlugin_csr_3072) begin
       _zz_CsrPlugin_csrMapping_readDataInit_18[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_19 = 32'h0;
     if(execute_CsrPlugin_csr_3200) begin
       _zz_CsrPlugin_csrMapping_readDataInit_19[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_20 = 32'h0;
     if(execute_CsrPlugin_csr_3074) begin
       _zz_CsrPlugin_csrMapping_readDataInit_20[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_21 = 32'h0;
     if(execute_CsrPlugin_csr_3202) begin
       _zz_CsrPlugin_csrMapping_readDataInit_21[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_22 = 32'h0;
     if(execute_CsrPlugin_csr_3008) begin
       _zz_CsrPlugin_csrMapping_readDataInit_22[31 : 0] = _zz_CsrPlugin_csrMapping_readDataInit;
     end
   end
 
   always @(*) begin
-    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h00000000;
+    _zz_CsrPlugin_csrMapping_readDataInit_23 = 32'h0;
     if(execute_CsrPlugin_csr_4032) begin
       _zz_CsrPlugin_csrMapping_readDataInit_23[31 : 0] = _zz_externalInterrupt;
     end
@@ -5127,10 +5130,11 @@ module VexRiscv (
   end
 
   assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
-  assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
+  assign when_InstructionCache_l242 = (iBusWishbone_ACK || iBusWishbone_ERR);
+  assign iBus_cmd_ready = (iBus_cmd_valid && (iBusWishbone_ACK || iBusWishbone_ERR));
   assign iBus_rsp_valid = _zz_iBus_rsp_valid;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
-  assign iBus_rsp_payload_error = 1'b0;
+  assign iBus_rsp_payload_error = iBusWishbone_ERR_regNext;
   assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
   assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
   assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
@@ -5142,12 +5146,12 @@ module VexRiscv (
   assign dBusWishbone_SEL = (_zz_dBus_cmd_ready_1 ? dBus_cmd_payload_mask : 4'b1111);
   assign dBusWishbone_WE = _zz_dBus_cmd_ready_1;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && dBusWishbone_ACK);
+  assign _zz_dBus_cmd_ready = (_zz_dBusWishbone_CYC && (dBusWishbone_ACK || dBusWishbone_ERR));
   assign dBusWishbone_CYC = _zz_dBusWishbone_CYC;
   assign dBusWishbone_STB = _zz_dBusWishbone_CYC;
   assign dBus_rsp_valid = _zz_dBus_rsp_valid;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
-  assign dBus_rsp_payload_error = 1'b0;
+  assign dBus_rsp_payload_error = dBusWishbone_ERR_regNext;
   always @(posedge clk) begin
     if(reset) begin
       IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
@@ -5163,10 +5167,10 @@ module VexRiscv (
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h00000000;
+      IBusCachedPlugin_rspCounter <= 32'h0;
       toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= 32'h00000000;
+      DBusCachedPlugin_rspCounter <= 32'h0;
       _zz_5 <= 1'b1;
       HazardSimplePlugin_writeBackBuffer_valid <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5175,8 +5179,8 @@ module VexRiscv (
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
-      CsrPlugin_mcycle <= 64'h0000000000000000;
-      CsrPlugin_minstret <= 64'h0000000000000000;
+      CsrPlugin_mcycle <= 64'h0;
+      CsrPlugin_minstret <= 64'h0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute <= 1'b0;
       CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory <= 1'b0;
@@ -5188,8 +5192,8 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      memory_DivPlugin_div_counter_value <= 6'h00;
-      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h00000000;
+      memory_DivPlugin_div_counter_value <= 6'h0;
+      _zz_CsrPlugin_csrMapping_readDataInit <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
@@ -5438,18 +5442,18 @@ module VexRiscv (
         end
       end
       if(when_InstructionCache_l239) begin
-        if(iBusWishbone_ACK) begin
+        if(when_InstructionCache_l242) begin
           _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
         end
       end
-      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && (iBusWishbone_ACK || iBusWishbone_ERR));
       if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
         _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
         if(_zz_dBus_cmd_ready_2) begin
           _zz_dBusWishbone_ADR <= 3'b000;
         end
       end
-      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_dBus_rsp_valid <= ((_zz_dBusWishbone_CYC && (! dBusWishbone_WE)) && (dBusWishbone_ACK || dBusWishbone_ERR));
     end
   end
 
@@ -5556,10 +5560,10 @@ module VexRiscv (
       end
     end
     if(when_MulDivIterativePlugin_l162) begin
-      memory_DivPlugin_accumulator <= 65'h00000000000000000;
+      memory_DivPlugin_accumulator <= 65'h0;
       memory_DivPlugin_rs1 <= ((_zz_memory_DivPlugin_rs1 ? (~ _zz_memory_DivPlugin_rs1_1) : _zz_memory_DivPlugin_rs1_1) + _zz_memory_DivPlugin_rs1_2);
       memory_DivPlugin_rs2 <= ((_zz_memory_DivPlugin_rs2 ? (~ execute_RS2) : execute_RS2) + _zz_memory_DivPlugin_rs2_1);
-      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h00000000) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_div_needRevert <= ((_zz_memory_DivPlugin_rs1 ^ (_zz_memory_DivPlugin_rs2 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if(when_Pipeline_l124) begin
@@ -5716,7 +5720,7 @@ module VexRiscv (
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if(when_Pipeline_l124_51) begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_PREDICTION_HAD_BRANCHED1 <= decode_PREDICTION_HAD_BRANCHED1;
     end
     if(when_Pipeline_l124_52) begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
@@ -5867,7 +5871,9 @@ module VexRiscv (
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
+    iBusWishbone_ERR_regNext <= iBusWishbone_ERR;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
+    dBusWishbone_ERR_regNext <= dBusWishbone_ERR;
   end
 
 
@@ -5944,8 +5950,8 @@ module DataCache (
   input  wire          reset
 );
 
-  reg        [21:0]   _zz_ways_0_tags_port0;
-  reg        [31:0]   _zz_ways_0_data_port0;
+  reg        [21:0]   ways_0_tags_spinal_port0;
+  reg        [31:0]   ways_0_data_spinal_port0;
   wire       [21:0]   _zz_ways_0_tags_port;
   wire       [31:0]   _zz_stageB_amo_addSub;
   wire       [31:0]   _zz_stageB_amo_addSub_1;
@@ -6137,7 +6143,7 @@ module DataCache (
   assign _zz_ways_0_tags_port = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
   always @(posedge clk) begin
     if(_zz_ways_0_tagsReadRsp_valid) begin
-      _zz_ways_0_tags_port0 <= ways_0_tags[tagsReadCmd_payload];
+      ways_0_tags_spinal_port0 <= ways_0_tags[tagsReadCmd_payload];
     end
   end
 
@@ -6148,7 +6154,7 @@ module DataCache (
   end
 
   always @(*) begin
-    _zz_ways_0_data_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
+    ways_0_data_spinal_port0 = {_zz_ways_0_datasymbol_read_3, _zz_ways_0_datasymbol_read_2, _zz_ways_0_datasymbol_read_1, _zz_ways_0_datasymbol_read};
   end
   always @(posedge clk) begin
     if(_zz_ways_0_dataReadRspMem) begin
@@ -6190,12 +6196,12 @@ module DataCache (
 
   assign haltCpu = 1'b0;
   assign _zz_ways_0_tagsReadRsp_valid = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_ways_0_tagsReadRsp_valid_1 = _zz_ways_0_tags_port0;
+  assign _zz_ways_0_tagsReadRsp_valid_1 = ways_0_tags_spinal_port0;
   assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
   assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
   assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRspMem = _zz_ways_0_data_port0;
+  assign ways_0_dataReadRspMem = ways_0_data_spinal_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
   assign when_DataCache_l645 = (tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]);
   assign when_DataCache_l648 = (dataWriteCmd_valid && dataWriteCmd_payload_way[0]);
@@ -6617,7 +6623,7 @@ module DataCache (
       if(!stageB_isExternalAmo) begin
         if(!when_DataCache_l996) begin
           if(!when_DataCache_l1009) begin
-            io_mem_cmd_payload_address[4 : 0] = 5'h00;
+            io_mem_cmd_payload_address[4 : 0] = 5'h0;
           end
         end
       end
@@ -6777,7 +6783,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h00;
+      stageB_flusher_counter <= 8'h0;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -6806,7 +6812,7 @@ module DataCache (
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h00;
+        stageB_flusher_counter <= 8'h0;
         if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
@@ -6900,8 +6906,8 @@ module InstructionCache (
   input  wire          reset
 );
 
-  reg        [31:0]   _zz_banks_0_port1;
-  reg        [22:0]   _zz_ways_0_tags_port1;
+  reg        [31:0]   banks_0_spinal_port1;
+  reg        [22:0]   ways_0_tags_spinal_port1;
   wire       [22:0]   _zz_ways_0_tags_port;
   reg                 _zz_1;
   reg                 _zz_2;
@@ -6917,7 +6923,7 @@ module InstructionCache (
   wire                when_InstructionCache_l351;
   reg                 lineLoader_cmdSent;
   wire                io_mem_cmd_fire;
-  wire                when_Utils_l566;
+  wire                when_Utils_l578;
   reg                 lineLoader_wayToAllocate_willIncrement;
   wire                lineLoader_wayToAllocate_willClear;
   wire                lineLoader_wayToAllocate_willOverflowIfInc;
@@ -6959,7 +6965,7 @@ module InstructionCache (
 
   always @(posedge clk) begin
     if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
-      _zz_banks_0_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
+      banks_0_spinal_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
     end
   end
 
@@ -6971,7 +6977,7 @@ module InstructionCache (
 
   always @(posedge clk) begin
     if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
-      _zz_ways_0_tags_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
+      ways_0_tags_spinal_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
     end
   end
 
@@ -7016,12 +7022,12 @@ module InstructionCache (
   assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
   assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
   assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h00};
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
   assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l566 = (! lineLoader_valid);
+  assign when_Utils_l578 = (! lineLoader_valid);
   always @(*) begin
     lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l566) begin
+    if(when_Utils_l578) begin
       lineLoader_wayToAllocate_willIncrement = 1'b1;
     end
   end
@@ -7040,11 +7046,11 @@ module InstructionCache (
   assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
   assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[10 : 2];
   assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_banks_0_port1;
+  assign fetchStage_read_banksValue_0_dataMem = banks_0_spinal_port1;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
   assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[10 : 5];
   assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
-  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = _zz_ways_0_tags_port1;
+  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = ways_0_tags_spinal_port1;
   assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
   assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
   assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
@@ -7106,7 +7112,7 @@ module InstructionCache (
     end
     _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[6];
     if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 7'h00;
+      lineLoader_flushCounter <= 7'h0;
     end
   end
 

--- a/gateware/src/vendor/soc/cpu/verilog/vexriscv/vexriscv_cynthion.v
+++ b/gateware/src/vendor/soc/cpu/verilog/vexriscv/vexriscv_cynthion.v
@@ -1,6 +1,6 @@
 // Generator : SpinalHDL v1.10.2a    git head : a348a60b7e8b6a455c72e1536ec3d74a2ea16935
 // Component : VexRiscv
-// Git hash  : fc66e9abeed6e890ecb698f989aa779fe0895bce
+// Git hash  : 828c35d05cfcaf856551faa415f9aeafde6a751c
 
 `timescale 1ns/1ps
 
@@ -9,8 +9,8 @@ module VexRiscv (
   input  wire          timerInterrupt,
   input  wire          softwareInterrupt,
   input  wire [31:0]   externalInterruptArray,
-  output reg           iBusWishbone_CYC,
-  output reg           iBusWishbone_STB,
+  output wire          iBusWishbone_CYC,
+  output wire          iBusWishbone_STB,
   input  wire          iBusWishbone_ACK,
   output wire          iBusWishbone_WE,
   output wire [29:0]   iBusWishbone_ADR,
@@ -62,16 +62,7 @@ module VexRiscv (
   localparam Src1CtrlEnum_PC_INCREMENT = 2'd2;
   localparam Src1CtrlEnum_URS1 = 2'd3;
 
-  wire                IBusCachedPlugin_cache_io_flush;
-  wire                IBusCachedPlugin_cache_io_cpu_prefetch_isValid;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_isValid;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_isStuck;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_isRemoved;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_isUser;
-  wire                IBusCachedPlugin_cache_io_cpu_decode_isValid;
-  wire                IBusCachedPlugin_cache_io_cpu_decode_isStuck;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_pc;
-  reg                 IBusCachedPlugin_cache_io_cpu_fill_valid;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready;
   wire                dataCache_1_io_cpu_execute_isValid;
   wire       [31:0]   dataCache_1_io_cpu_execute_address;
   reg                 dataCache_1_io_cpu_execute_args_isLrsc;
@@ -95,21 +86,15 @@ module VexRiscv (
   wire       [3:0]    dataCache_1_io_cpu_writeBack_fence_FM;
   wire                dataCache_1_io_cpu_flush_valid;
   wire                dataCache_1_io_cpu_flush_payload_singleLine;
-  wire       [6:0]    dataCache_1_io_cpu_flush_payload_lineId;
+  wire       [4:0]    dataCache_1_io_cpu_flush_payload_lineId;
   reg        [31:0]   RegFilePlugin_regFile_spinal_port0;
   reg        [31:0]   RegFilePlugin_regFile_spinal_port1;
-  wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_error;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuException;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_data;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
-  wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
+  wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy;
+  wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_availability;
   wire                dataCache_1_io_cpu_execute_haltIt;
   wire                dataCache_1_io_cpu_execute_refilling;
   wire                dataCache_1_io_cpu_memory_isWrite;
@@ -168,34 +153,43 @@ module VexRiscv (
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_20;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_21;
   wire       [31:0]   _zz_decode_LEGAL_INSTRUCTION_22;
-  wire       [3:0]    _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1;
-  reg        [31:0]   _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
-  wire       [1:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_6;
-  wire       [31:0]   _zz_IBusCachedPlugin_fetchPc_pc;
-  wire       [2:0]    _zz_IBusCachedPlugin_fetchPc_pc_1;
-  wire       [31:0]   _zz_IBusCachedPlugin_decodePc_pcPlus;
-  wire       [2:0]    _zz_IBusCachedPlugin_decodePc_pcPlus_1;
-  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_27;
-  wire       [0:0]    _zz_IBusCachedPlugin_decompressor_decompressed_28;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_29;
-  wire       [31:0]   _zz_IBusCachedPlugin_decompressor_decompressed_30;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_31;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_32;
-  wire       [6:0]    _zz_IBusCachedPlugin_decompressor_decompressed_33;
-  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_34;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_35;
-  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_36;
-  wire       [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_37;
-  wire       [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_38;
-  wire       [11:0]   _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  wire       [31:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2;
-  wire       [19:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload;
-  wire       [11:0]   _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-  wire       [0:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_4;
-  wire       [7:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_5;
-  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_6;
-  wire       [0:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_7;
-  wire       [0:0]    _zz_IBusCachedPlugin_predictionJumpInterface_payload_8;
+  wire       [3:0]    _zz__zz_IBusSimplePlugin_jump_pcLoad_payload_1;
+  reg        [31:0]   _zz_IBusSimplePlugin_jump_pcLoad_payload_5;
+  wire       [1:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_6;
+  wire       [31:0]   _zz_IBusSimplePlugin_fetchPc_pc;
+  wire       [2:0]    _zz_IBusSimplePlugin_fetchPc_pc_1;
+  wire       [31:0]   _zz_IBusSimplePlugin_decodePc_pcPlus;
+  wire       [2:0]    _zz_IBusSimplePlugin_decodePc_pcPlus_1;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_27;
+  wire       [0:0]    _zz_IBusSimplePlugin_decompressor_decompressed_28;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_29;
+  wire       [31:0]   _zz_IBusSimplePlugin_decompressor_decompressed_30;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_31;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_32;
+  wire       [6:0]    _zz_IBusSimplePlugin_decompressor_decompressed_33;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_34;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_35;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_36;
+  wire       [11:0]   _zz_IBusSimplePlugin_decompressor_decompressed_37;
+  wire       [11:0]   _zz_IBusSimplePlugin_decompressor_decompressed_38;
+  wire       [11:0]   _zz__zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+  wire       [31:0]   _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_2;
+  wire       [19:0]   _zz__zz_IBusSimplePlugin_predictionJumpInterface_payload;
+  wire       [11:0]   _zz__zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+  wire       [0:0]    _zz_IBusSimplePlugin_predictionJumpInterface_payload_4;
+  wire       [7:0]    _zz_IBusSimplePlugin_predictionJumpInterface_payload_5;
+  wire                _zz_IBusSimplePlugin_predictionJumpInterface_payload_6;
+  wire       [0:0]    _zz_IBusSimplePlugin_predictionJumpInterface_payload_7;
+  wire       [0:0]    _zz_IBusSimplePlugin_predictionJumpInterface_payload_8;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next_1;
+  wire       [0:0]    _zz_IBusSimplePlugin_pending_next_2;
+  wire       [2:0]    _zz_IBusSimplePlugin_pending_next_3;
+  wire       [0:0]    _zz_IBusSimplePlugin_pending_next_4;
+  wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter;
+  wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1;
+  wire       [2:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2;
+  wire       [0:0]    _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3;
   wire       [26:0]   _zz_io_cpu_flush_payload_lineId;
   wire       [26:0]   _zz_io_cpu_flush_payload_lineId_1;
   wire       [2:0]    _zz_DBusCachedPlugin_exceptionBus_payload_code;
@@ -217,7 +211,7 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_9;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_10;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_11;
-  wire       [27:0]   _zz__zz_decode_IS_RS2_SIGNED_12;
+  wire       [26:0]   _zz__zz_decode_IS_RS2_SIGNED_12;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_13;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_14;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_15;
@@ -230,7 +224,7 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_22;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_23;
   wire                _zz__zz_decode_IS_RS2_SIGNED_24;
-  wire       [23:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
+  wire       [22:0]   _zz__zz_decode_IS_RS2_SIGNED_25;
   wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_26;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_27;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_28;
@@ -239,7 +233,7 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_31;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_32;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_33;
-  wire       [20:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
+  wire       [19:0]   _zz__zz_decode_IS_RS2_SIGNED_34;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_35;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_36;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_37;
@@ -254,7 +248,7 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_46;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_47;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_48;
-  wire       [16:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
+  wire       [15:0]   _zz__zz_decode_IS_RS2_SIGNED_49;
   wire                _zz__zz_decode_IS_RS2_SIGNED_50;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_51;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_52;
@@ -280,7 +274,7 @@ module VexRiscv (
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_72;
   wire                _zz__zz_decode_IS_RS2_SIGNED_73;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_74;
-  wire       [12:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
+  wire       [11:0]   _zz__zz_decode_IS_RS2_SIGNED_75;
   wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_76;
   wire                _zz__zz_decode_IS_RS2_SIGNED_77;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_78;
@@ -323,7 +317,7 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_115;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_116;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_117;
-  wire       [9:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
+  wire       [8:0]    _zz__zz_decode_IS_RS2_SIGNED_118;
   wire                _zz__zz_decode_IS_RS2_SIGNED_119;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_120;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_121;
@@ -333,7 +327,7 @@ module VexRiscv (
   wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_125;
   wire                _zz__zz_decode_IS_RS2_SIGNED_126;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_127;
-  wire       [7:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
+  wire       [6:0]    _zz__zz_decode_IS_RS2_SIGNED_128;
   wire                _zz__zz_decode_IS_RS2_SIGNED_129;
   wire                _zz__zz_decode_IS_RS2_SIGNED_130;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_131;
@@ -341,7 +335,7 @@ module VexRiscv (
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_133;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_134;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_135;
-  wire       [5:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
+  wire       [4:0]    _zz__zz_decode_IS_RS2_SIGNED_136;
   wire                _zz__zz_decode_IS_RS2_SIGNED_137;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_138;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_139;
@@ -356,7 +350,7 @@ module VexRiscv (
   wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_148;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_149;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_150;
-  wire       [3:0]    _zz__zz_decode_IS_RS2_SIGNED_151;
+  wire       [2:0]    _zz__zz_decode_IS_RS2_SIGNED_151;
   wire                _zz__zz_decode_IS_RS2_SIGNED_152;
   wire                _zz__zz_decode_IS_RS2_SIGNED_153;
   wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_154;
@@ -368,12 +362,10 @@ module VexRiscv (
   wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_160;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_161;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_162;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
-  wire       [1:0]    _zz__zz_decode_IS_RS2_SIGNED_164;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_165;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_163;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_164;
+  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_165;
   wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_166;
-  wire       [0:0]    _zz__zz_decode_IS_RS2_SIGNED_167;
-  wire       [31:0]   _zz__zz_decode_IS_RS2_SIGNED_168;
   wire                _zz_RegFilePlugin_regFile_port;
   wire                _zz_decode_RegFilePlugin_rs1Data;
   wire                _zz_RegFilePlugin_regFile_port_1;
@@ -395,9 +387,6 @@ module VexRiscv (
   wire       [0:0]    _zz_execute_BranchPlugin_branch_src2_9;
   wire       [0:0]    _zz_execute_BranchPlugin_branch_src2_10;
   wire       [2:0]    _zz_execute_BranchPlugin_branch_src2_11;
-  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
-  wire       [1:0]    _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1;
-  wire                _zz_when;
   wire       [65:0]   _zz_writeBack_MulPlugin_result;
   wire       [65:0]   _zz_writeBack_MulPlugin_result_1;
   wire       [31:0]   _zz__zz_decode_RS2_2;
@@ -418,7 +407,6 @@ module VexRiscv (
   wire       [31:0]   _zz_memory_DivPlugin_rs2_1;
   wire       [0:0]    _zz_memory_DivPlugin_rs2_2;
   wire       [31:0]   _zz_CsrPlugin_csrMapping_readDataInit_24;
-  wire       [26:0]   _zz_iBusWishbone_ADR_1;
   wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
@@ -585,11 +573,6 @@ module VexRiscv (
   wire                decode_MEMORY_LRSC;
   reg                 _zz_decode_MEMORY_FORCE_CONSTISTENCY;
   wire                decode_MEMORY_ENABLE;
-  wire                decode_FLUSH_ALL;
-  reg                 IBusCachedPlugin_rsp_issueDetected_4;
-  reg                 IBusCachedPlugin_rsp_issueDetected_3;
-  reg                 IBusCachedPlugin_rsp_issueDetected_2;
-  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       [1:0]    decode_BRANCH_CTRL;
   wire       [1:0]    _zz_decode_BRANCH_CTRL_1;
   reg        [31:0]   _zz_memory_to_writeBack_FORMAL_PC_NEXT;
@@ -647,35 +630,23 @@ module VexRiscv (
   wire       [31:0]   lastStagePc /* verilator public */ ;
   wire                lastStageIsValid /* verilator public */ ;
   wire                lastStageIsFiring /* verilator public */ ;
-  reg                 IBusCachedPlugin_fetcherHalt;
-  wire                IBusCachedPlugin_forceNoDecodeCond;
-  reg                 IBusCachedPlugin_incomingInstruction;
-  wire                IBusCachedPlugin_predictionJumpInterface_valid;
-  (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
-  wire                IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  wire                IBusCachedPlugin_decodePrediction_rsp_wasWrong;
-  wire                IBusCachedPlugin_pcValids_0;
-  wire                IBusCachedPlugin_pcValids_1;
-  wire                IBusCachedPlugin_pcValids_2;
-  wire                IBusCachedPlugin_pcValids_3;
-  reg                 IBusCachedPlugin_decodeExceptionPort_valid;
-  reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
-  wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
-  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
-  wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
-  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
-  wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
-  wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
-  wire                IBusCachedPlugin_mmuBus_rsp_allowExecute;
-  wire                IBusCachedPlugin_mmuBus_rsp_exception;
-  wire                IBusCachedPlugin_mmuBus_rsp_refilling;
-  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
-  wire                IBusCachedPlugin_mmuBus_end;
-  wire                IBusCachedPlugin_mmuBus_busy;
+  reg                 IBusSimplePlugin_fetcherHalt;
+  wire                IBusSimplePlugin_forceNoDecodeCond;
+  reg                 IBusSimplePlugin_incomingInstruction;
+  wire                IBusSimplePlugin_predictionJumpInterface_valid;
+  (* keep , syn_keep *) wire       [31:0]   IBusSimplePlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
+  wire                IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+  wire                IBusSimplePlugin_decodePrediction_rsp_wasWrong;
+  wire                IBusSimplePlugin_pcValids_0;
+  wire                IBusSimplePlugin_pcValids_1;
+  wire                IBusSimplePlugin_pcValids_2;
+  wire                IBusSimplePlugin_pcValids_3;
+  wire                iBus_cmd_valid;
+  reg                 iBus_cmd_ready;
+  wire       [31:0]   iBus_cmd_payload_pc;
+  wire                iBus_rsp_valid;
+  wire                iBus_rsp_payload_error;
+  wire       [31:0]   iBus_rsp_payload_inst;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -740,174 +711,189 @@ module VexRiscv (
   wire                CsrPlugin_allowException;
   wire                CsrPlugin_allowEbreakException;
   wire                CsrPlugin_xretAwayFromMachine;
-  wire                IBusCachedPlugin_externalFlush;
-  wire                IBusCachedPlugin_jump_pcLoad_valid;
-  wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_IBusCachedPlugin_jump_pcLoad_payload_1;
-  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_2;
-  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_3;
-  wire                _zz_IBusCachedPlugin_jump_pcLoad_payload_4;
-  wire                IBusCachedPlugin_fetchPc_output_valid;
-  wire                IBusCachedPlugin_fetchPc_output_ready;
-  wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
-  reg        [31:0]   IBusCachedPlugin_fetchPc_pcReg /* verilator public */ ;
-  reg                 IBusCachedPlugin_fetchPc_correction;
-  reg                 IBusCachedPlugin_fetchPc_correctionReg;
-  wire                IBusCachedPlugin_fetchPc_output_fire;
-  wire                IBusCachedPlugin_fetchPc_corrected;
-  reg                 IBusCachedPlugin_fetchPc_pcRegPropagate;
-  reg                 IBusCachedPlugin_fetchPc_booted;
-  reg                 IBusCachedPlugin_fetchPc_inc;
+  wire                IBusSimplePlugin_externalFlush;
+  wire                IBusSimplePlugin_jump_pcLoad_valid;
+  wire       [31:0]   IBusSimplePlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload;
+  wire       [3:0]    _zz_IBusSimplePlugin_jump_pcLoad_payload_1;
+  wire                _zz_IBusSimplePlugin_jump_pcLoad_payload_2;
+  wire                _zz_IBusSimplePlugin_jump_pcLoad_payload_3;
+  wire                _zz_IBusSimplePlugin_jump_pcLoad_payload_4;
+  wire                IBusSimplePlugin_fetchPc_output_valid;
+  wire                IBusSimplePlugin_fetchPc_output_ready;
+  wire       [31:0]   IBusSimplePlugin_fetchPc_output_payload;
+  reg        [31:0]   IBusSimplePlugin_fetchPc_pcReg /* verilator public */ ;
+  reg                 IBusSimplePlugin_fetchPc_correction;
+  reg                 IBusSimplePlugin_fetchPc_correctionReg;
+  wire                IBusSimplePlugin_fetchPc_output_fire;
+  wire                IBusSimplePlugin_fetchPc_corrected;
+  reg                 IBusSimplePlugin_fetchPc_pcRegPropagate;
+  reg                 IBusSimplePlugin_fetchPc_booted;
+  reg                 IBusSimplePlugin_fetchPc_inc;
   wire                when_Fetcher_l133;
   wire                when_Fetcher_l133_1;
-  reg        [31:0]   IBusCachedPlugin_fetchPc_pc;
-  wire                IBusCachedPlugin_fetchPc_redo_valid;
-  reg        [31:0]   IBusCachedPlugin_fetchPc_redo_payload;
-  reg                 IBusCachedPlugin_fetchPc_flushed;
+  reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
+  reg                 IBusSimplePlugin_fetchPc_flushed;
   wire                when_Fetcher_l160;
-  reg                 IBusCachedPlugin_decodePc_flushed;
-  reg        [31:0]   IBusCachedPlugin_decodePc_pcReg /* verilator public */ ;
-  wire       [31:0]   IBusCachedPlugin_decodePc_pcPlus;
-  wire                IBusCachedPlugin_decodePc_injectedDecode;
+  reg                 IBusSimplePlugin_decodePc_flushed;
+  reg        [31:0]   IBusSimplePlugin_decodePc_pcReg /* verilator public */ ;
+  wire       [31:0]   IBusSimplePlugin_decodePc_pcPlus;
+  wire                IBusSimplePlugin_decodePc_injectedDecode;
   wire                when_Fetcher_l182;
   wire                when_Fetcher_l194;
-  reg                 IBusCachedPlugin_iBusRsp_redoFetch;
-  wire                IBusCachedPlugin_iBusRsp_stages_0_input_valid;
-  wire                IBusCachedPlugin_iBusRsp_stages_0_input_ready;
-  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_0_input_payload;
-  wire                IBusCachedPlugin_iBusRsp_stages_0_output_valid;
-  wire                IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_0_output_payload;
-  reg                 IBusCachedPlugin_iBusRsp_stages_0_halt;
-  wire                IBusCachedPlugin_iBusRsp_stages_1_input_valid;
-  wire                IBusCachedPlugin_iBusRsp_stages_1_input_ready;
-  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  wire                IBusCachedPlugin_iBusRsp_stages_1_output_valid;
-  wire                IBusCachedPlugin_iBusRsp_stages_1_output_ready;
-  wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_payload;
-  reg                 IBusCachedPlugin_iBusRsp_stages_1_halt;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready;
-  wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  wire                _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
-  reg                 _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
-  reg                 IBusCachedPlugin_iBusRsp_readyForError;
-  wire                IBusCachedPlugin_iBusRsp_output_valid;
-  wire                IBusCachedPlugin_iBusRsp_output_ready;
-  wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_pc;
-  wire                IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
-  wire       [31:0]   IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  wire                IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  wire                IBusCachedPlugin_decompressor_input_valid;
-  wire                IBusCachedPlugin_decompressor_input_ready;
-  wire       [31:0]   IBusCachedPlugin_decompressor_input_payload_pc;
-  wire                IBusCachedPlugin_decompressor_input_payload_rsp_error;
-  wire       [31:0]   IBusCachedPlugin_decompressor_input_payload_rsp_inst;
-  wire                IBusCachedPlugin_decompressor_input_payload_isRvc;
-  wire                IBusCachedPlugin_decompressor_output_valid;
-  wire                IBusCachedPlugin_decompressor_output_ready;
-  wire       [31:0]   IBusCachedPlugin_decompressor_output_payload_pc;
-  wire                IBusCachedPlugin_decompressor_output_payload_rsp_error;
-  wire       [31:0]   IBusCachedPlugin_decompressor_output_payload_rsp_inst;
-  wire                IBusCachedPlugin_decompressor_output_payload_isRvc;
-  wire                IBusCachedPlugin_decompressor_flushNext;
-  wire                IBusCachedPlugin_decompressor_consumeCurrent;
-  reg                 IBusCachedPlugin_decompressor_bufferValid;
-  reg        [15:0]   IBusCachedPlugin_decompressor_bufferData;
-  wire                IBusCachedPlugin_decompressor_isInputLowRvc;
-  wire                IBusCachedPlugin_decompressor_isInputHighRvc;
-  reg                 IBusCachedPlugin_decompressor_throw2BytesReg;
-  wire                IBusCachedPlugin_decompressor_throw2Bytes;
-  wire                IBusCachedPlugin_decompressor_unaligned;
-  reg                 IBusCachedPlugin_decompressor_bufferValidLatch;
-  reg                 IBusCachedPlugin_decompressor_throw2BytesLatch;
-  wire                IBusCachedPlugin_decompressor_bufferValidPatched;
-  wire                IBusCachedPlugin_decompressor_throw2BytesPatched;
-  wire       [31:0]   IBusCachedPlugin_decompressor_raw;
-  wire                IBusCachedPlugin_decompressor_isRvc;
-  wire       [15:0]   _zz_IBusCachedPlugin_decompressor_decompressed;
-  reg        [31:0]   IBusCachedPlugin_decompressor_decompressed;
-  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_1;
-  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_2;
-  wire       [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_3;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_4;
-  reg        [11:0]   _zz_IBusCachedPlugin_decompressor_decompressed_5;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_6;
-  reg        [9:0]    _zz_IBusCachedPlugin_decompressor_decompressed_7;
-  wire       [20:0]   _zz_IBusCachedPlugin_decompressor_decompressed_8;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_9;
-  reg        [14:0]   _zz_IBusCachedPlugin_decompressor_decompressed_10;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_11;
-  reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_12;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_13;
-  reg        [9:0]    _zz_IBusCachedPlugin_decompressor_decompressed_14;
-  wire       [20:0]   _zz_IBusCachedPlugin_decompressor_decompressed_15;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_16;
-  reg        [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_17;
-  wire       [12:0]   _zz_IBusCachedPlugin_decompressor_decompressed_18;
-  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_19;
-  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_20;
-  wire       [4:0]    _zz_IBusCachedPlugin_decompressor_decompressed_21;
+  wire                IBusSimplePlugin_iBusRsp_redoFetch;
+  wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
+  wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_0_input_payload;
+  wire                IBusSimplePlugin_iBusRsp_stages_0_output_valid;
+  wire                IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_0_output_payload;
+  reg                 IBusSimplePlugin_iBusRsp_stages_0_halt;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_input_valid;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_input_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_1_input_payload;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_output_valid;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_output_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_1_output_payload;
+  wire                IBusSimplePlugin_iBusRsp_stages_1_halt;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready;
+  wire                IBusSimplePlugin_iBusRsp_flush;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  wire                _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid;
+  reg                 _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1;
+  reg                 IBusSimplePlugin_iBusRsp_readyForError;
+  wire                IBusSimplePlugin_iBusRsp_output_valid;
+  wire                IBusSimplePlugin_iBusRsp_output_ready;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_output_payload_pc;
+  wire                IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
+  wire                IBusSimplePlugin_iBusRsp_output_payload_isRvc;
+  wire                IBusSimplePlugin_decompressor_input_valid;
+  wire                IBusSimplePlugin_decompressor_input_ready;
+  wire       [31:0]   IBusSimplePlugin_decompressor_input_payload_pc;
+  wire                IBusSimplePlugin_decompressor_input_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_decompressor_input_payload_rsp_inst;
+  wire                IBusSimplePlugin_decompressor_input_payload_isRvc;
+  wire                IBusSimplePlugin_decompressor_output_valid;
+  wire                IBusSimplePlugin_decompressor_output_ready;
+  wire       [31:0]   IBusSimplePlugin_decompressor_output_payload_pc;
+  wire                IBusSimplePlugin_decompressor_output_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_decompressor_output_payload_rsp_inst;
+  wire                IBusSimplePlugin_decompressor_output_payload_isRvc;
+  wire                IBusSimplePlugin_decompressor_flushNext;
+  wire                IBusSimplePlugin_decompressor_consumeCurrent;
+  reg                 IBusSimplePlugin_decompressor_bufferValid;
+  reg        [15:0]   IBusSimplePlugin_decompressor_bufferData;
+  wire                IBusSimplePlugin_decompressor_isInputLowRvc;
+  wire                IBusSimplePlugin_decompressor_isInputHighRvc;
+  reg                 IBusSimplePlugin_decompressor_throw2BytesReg;
+  wire                IBusSimplePlugin_decompressor_throw2Bytes;
+  wire                IBusSimplePlugin_decompressor_unaligned;
+  reg                 IBusSimplePlugin_decompressor_bufferValidLatch;
+  reg                 IBusSimplePlugin_decompressor_throw2BytesLatch;
+  wire                IBusSimplePlugin_decompressor_bufferValidPatched;
+  wire                IBusSimplePlugin_decompressor_throw2BytesPatched;
+  wire       [31:0]   IBusSimplePlugin_decompressor_raw;
+  wire                IBusSimplePlugin_decompressor_isRvc;
+  wire       [15:0]   _zz_IBusSimplePlugin_decompressor_decompressed;
+  reg        [31:0]   IBusSimplePlugin_decompressor_decompressed;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_1;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_2;
+  wire       [11:0]   _zz_IBusSimplePlugin_decompressor_decompressed_3;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_4;
+  reg        [11:0]   _zz_IBusSimplePlugin_decompressor_decompressed_5;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_6;
+  reg        [9:0]    _zz_IBusSimplePlugin_decompressor_decompressed_7;
+  wire       [20:0]   _zz_IBusSimplePlugin_decompressor_decompressed_8;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_9;
+  reg        [14:0]   _zz_IBusSimplePlugin_decompressor_decompressed_10;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_11;
+  reg        [2:0]    _zz_IBusSimplePlugin_decompressor_decompressed_12;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_13;
+  reg        [9:0]    _zz_IBusSimplePlugin_decompressor_decompressed_14;
+  wire       [20:0]   _zz_IBusSimplePlugin_decompressor_decompressed_15;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_16;
+  reg        [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_17;
+  wire       [12:0]   _zz_IBusSimplePlugin_decompressor_decompressed_18;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_19;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_20;
+  wire       [4:0]    _zz_IBusSimplePlugin_decompressor_decompressed_21;
   wire       [4:0]    switch_Misc_l44;
   wire                when_Misc_l47;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_22;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_22;
   wire       [1:0]    switch_Misc_l241;
   wire       [1:0]    switch_Misc_l241_1;
-  reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_23;
-  reg        [2:0]    _zz_IBusCachedPlugin_decompressor_decompressed_24;
-  wire                _zz_IBusCachedPlugin_decompressor_decompressed_25;
-  reg        [6:0]    _zz_IBusCachedPlugin_decompressor_decompressed_26;
-  wire                IBusCachedPlugin_decompressor_output_fire;
-  wire                IBusCachedPlugin_decompressor_bufferFill;
+  reg        [2:0]    _zz_IBusSimplePlugin_decompressor_decompressed_23;
+  reg        [2:0]    _zz_IBusSimplePlugin_decompressor_decompressed_24;
+  wire                _zz_IBusSimplePlugin_decompressor_decompressed_25;
+  reg        [6:0]    _zz_IBusSimplePlugin_decompressor_decompressed_26;
+  wire                IBusSimplePlugin_decompressor_output_fire;
+  wire                IBusSimplePlugin_decompressor_bufferFill;
   wire                when_Fetcher_l285;
   wire                when_Fetcher_l288;
   wire                when_Fetcher_l293;
-  wire                IBusCachedPlugin_injector_decodeInput_valid;
-  wire                IBusCachedPlugin_injector_decodeInput_ready;
-  wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_pc;
-  wire                IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
-  wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
-  wire                IBusCachedPlugin_injector_decodeInput_payload_isRvc;
-  reg                 _zz_IBusCachedPlugin_injector_decodeInput_valid;
-  reg        [31:0]   _zz_IBusCachedPlugin_injector_decodeInput_payload_pc;
-  reg                 _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
-  reg        [31:0]   _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
-  reg                 _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
-  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
+  wire                IBusSimplePlugin_injector_decodeInput_valid;
+  wire                IBusSimplePlugin_injector_decodeInput_ready;
+  wire       [31:0]   IBusSimplePlugin_injector_decodeInput_payload_pc;
+  wire                IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  wire                IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_valid;
+  reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_pc;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  reg        [31:0]   _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  reg                 _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
+  reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
   wire                when_Fetcher_l331;
-  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
+  reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
   wire                when_Fetcher_l331_1;
-  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
+  reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
   wire                when_Fetcher_l331_2;
-  reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
+  reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
   wire                when_Fetcher_l331_3;
-  reg        [31:0]   IBusCachedPlugin_injector_formal_rawInDecode;
-  wire                _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  reg        [18:0]   _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1;
-  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-  reg        [10:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_1;
-  wire                _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-  reg        [18:0]   _zz_IBusCachedPlugin_predictionJumpInterface_payload_3;
-  wire                iBus_cmd_valid;
-  wire                iBus_cmd_ready;
-  reg        [31:0]   iBus_cmd_payload_address;
-  wire       [2:0]    iBus_cmd_payload_size;
-  wire                iBus_rsp_valid;
-  wire       [31:0]   iBus_rsp_payload_data;
-  wire                iBus_rsp_payload_error;
-  reg        [31:0]   IBusCachedPlugin_rspCounter;
-  wire                IBusCachedPlugin_s0_tightlyCoupledHit;
-  reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
-  wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
-  wire                IBusCachedPlugin_rsp_issueDetected;
-  reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                when_IBusCachedPlugin_l245;
-  wire                when_IBusCachedPlugin_l250;
-  wire                when_IBusCachedPlugin_l256;
-  wire                when_IBusCachedPlugin_l262;
-  wire                when_IBusCachedPlugin_l273;
+  reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
+  wire                _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+  reg        [18:0]   _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1;
+  wire                _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+  reg        [10:0]   _zz_IBusSimplePlugin_predictionJumpInterface_payload_1;
+  wire                _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+  reg        [18:0]   _zz_IBusSimplePlugin_predictionJumpInterface_payload_3;
+  wire                IBusSimplePlugin_cmd_valid;
+  wire                IBusSimplePlugin_cmd_ready;
+  wire       [31:0]   IBusSimplePlugin_cmd_payload_pc;
+  wire                IBusSimplePlugin_pending_inc;
+  wire                IBusSimplePlugin_pending_dec;
+  reg        [2:0]    IBusSimplePlugin_pending_value;
+  wire       [2:0]    IBusSimplePlugin_pending_next;
+  wire                IBusSimplePlugin_cmdFork_canEmit;
+  wire                when_IBusSimplePlugin_l305;
+  wire                IBusSimplePlugin_cmd_fire;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_output_valid;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_output_ready;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
+  reg        [2:0]    IBusSimplePlugin_rspJoin_rspBuffer_discardCounter;
+  wire                iBus_rsp_toStream_valid;
+  wire                iBus_rsp_toStream_ready;
+  wire                iBus_rsp_toStream_payload_error;
+  wire       [31:0]   iBus_rsp_toStream_payload_inst;
+  wire                IBusSimplePlugin_rspJoin_rspBuffer_flush;
+  wire                toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_pc;
+  reg                 IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
+  wire                IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
+  wire                when_IBusSimplePlugin_l376;
+  wire                IBusSimplePlugin_rspJoin_join_valid;
+  wire                IBusSimplePlugin_rspJoin_join_ready;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_pc;
+  wire                IBusSimplePlugin_rspJoin_join_payload_rsp_error;
+  wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
+  wire                IBusSimplePlugin_rspJoin_join_payload_isRvc;
+  wire                IBusSimplePlugin_rspJoin_exceptionDetected;
+  wire                IBusSimplePlugin_rspJoin_join_fire;
+  wire                _zz_IBusSimplePlugin_iBusRsp_output_valid;
   wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid;
   reg                 toplevel_dataCache_1_io_mem_cmd_s2mPipe_ready;
   wire                toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
@@ -969,7 +955,7 @@ module VexRiscv (
   reg        [31:0]   _zz_writeBack_DBusCachedPlugin_rspFormated_3;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
   wire                when_DBusCachedPlugin_l581;
-  wire       [34:0]   _zz_decode_IS_RS2_SIGNED;
+  wire       [33:0]   _zz_decode_IS_RS2_SIGNED;
   wire                _zz_decode_IS_RS2_SIGNED_1;
   wire                _zz_decode_IS_RS2_SIGNED_2;
   wire                _zz_decode_IS_RS2_SIGNED_3;
@@ -1086,8 +1072,6 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code;
-  wire                _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1;
   wire                when_CsrPlugin_l1259;
   wire                when_CsrPlugin_l1259_1;
   wire                when_CsrPlugin_l1259_2;
@@ -1410,12 +1394,12 @@ module VexRiscv (
   reg                 when_CsrPlugin_l1719;
   wire                when_CsrPlugin_l1717;
   wire                when_CsrPlugin_l1725;
-  reg        [2:0]    _zz_iBusWishbone_ADR;
-  wire                when_InstructionCache_l239;
-  wire                when_InstructionCache_l242;
-  reg                 _zz_iBus_rsp_valid;
-  reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg                 iBusWishbone_ERR_regNext;
+  wire                iBus_cmd_m2sPipe_valid;
+  wire                iBus_cmd_m2sPipe_ready;
+  wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
+  reg                 iBus_cmd_rValid;
+  reg        [31:0]   iBus_cmd_rData_pc;
+  wire                when_Stream_l375_1;
   reg        [2:0]    _zz_dBusWishbone_ADR;
   wire                _zz_dBusWishbone_CYC;
   wire                _zz_dBus_cmd_ready;
@@ -1508,7 +1492,6 @@ module VexRiscv (
 
   reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_when = (|{decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid});
   assign _zz_memory_MUL_LOW = ($signed(_zz_memory_MUL_LOW_1) + $signed(_zz_memory_MUL_LOW_4));
   assign _zz_memory_MUL_LOW_1 = ($signed(52'h0) + $signed(_zz_memory_MUL_LOW_2));
   assign _zz_memory_MUL_LOW_3 = {1'b0,memory_MUL_LL};
@@ -1522,18 +1505,27 @@ module VexRiscv (
   assign _zz_execute_SHIFT_RIGHT_2 = {((execute_SHIFT_CTRL == ShiftCtrlEnum_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
   assign _zz_decode_FORMAL_PC_NEXT_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
   assign _zz_decode_FORMAL_PC_NEXT = {29'd0, _zz_decode_FORMAL_PC_NEXT_1};
-  assign _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload - 4'b0001);
-  assign _zz_IBusCachedPlugin_fetchPc_pc_1 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_IBusCachedPlugin_fetchPc_pc = {29'd0, _zz_IBusCachedPlugin_fetchPc_pc_1};
-  assign _zz_IBusCachedPlugin_decodePc_pcPlus_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz_IBusCachedPlugin_decodePc_pcPlus = {29'd0, _zz_IBusCachedPlugin_decodePc_pcPlus_1};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_30 = {{_zz_IBusCachedPlugin_decompressor_decompressed_10,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},12'h0};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_37 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_38 = {{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[8 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 9]},2'b00};
-  assign _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz__zz_IBusSimplePlugin_jump_pcLoad_payload_1 = (_zz_IBusSimplePlugin_jump_pcLoad_payload - 4'b0001);
+  assign _zz_IBusSimplePlugin_fetchPc_pc_1 = {IBusSimplePlugin_fetchPc_inc,2'b00};
+  assign _zz_IBusSimplePlugin_fetchPc_pc = {29'd0, _zz_IBusSimplePlugin_fetchPc_pc_1};
+  assign _zz_IBusSimplePlugin_decodePc_pcPlus_1 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_IBusSimplePlugin_decodePc_pcPlus = {29'd0, _zz_IBusSimplePlugin_decodePc_pcPlus_1};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_30 = {{_zz_IBusSimplePlugin_decompressor_decompressed_10,_zz_IBusSimplePlugin_decompressor_decompressed[6 : 2]},12'h0};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_37 = {{{4'b0000,_zz_IBusSimplePlugin_decompressor_decompressed[8 : 7]},_zz_IBusSimplePlugin_decompressor_decompressed[12 : 9]},2'b00};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_38 = {{{4'b0000,_zz_IBusSimplePlugin_decompressor_decompressed[8 : 7]},_zz_IBusSimplePlugin_decompressor_decompressed[12 : 9]},2'b00};
+  assign _zz__zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_2 = {{_zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz__zz_IBusSimplePlugin_predictionJumpInterface_payload = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz__zz_IBusSimplePlugin_predictionJumpInterface_payload_2 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_IBusSimplePlugin_pending_next = (IBusSimplePlugin_pending_value + _zz_IBusSimplePlugin_pending_next_1);
+  assign _zz_IBusSimplePlugin_pending_next_2 = IBusSimplePlugin_pending_inc;
+  assign _zz_IBusSimplePlugin_pending_next_1 = {2'd0, _zz_IBusSimplePlugin_pending_next_2};
+  assign _zz_IBusSimplePlugin_pending_next_4 = IBusSimplePlugin_pending_dec;
+  assign _zz_IBusSimplePlugin_pending_next_3 = {2'd0, _zz_IBusSimplePlugin_pending_next_4};
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1 = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000));
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter = {2'd0, _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_1};
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3 = IBusSimplePlugin_pending_dec;
+  assign _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2 = {2'd0, _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_3};
   assign _zz_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId_1;
   assign _zz_io_cpu_flush_payload_lineId_1 = (execute_RS1 >>> 3'd5);
   assign _zz_DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
@@ -1551,8 +1543,6 @@ module VexRiscv (
   assign _zz__zz_execute_BranchPlugin_branch_src2_2 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
   assign _zz__zz_execute_BranchPlugin_branch_src2_4 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
   assign _zz_execute_BranchPlugin_branch_src2_11 = (execute_IS_RVC ? 3'b010 : 3'b100);
-  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code & (~ _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1));
-  assign _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1_1 = (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code - 2'b01);
   assign _zz_writeBack_MulPlugin_result = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
   assign _zz_writeBack_MulPlugin_result_1 = ({32'd0,writeBack_MUL_HH} <<< 6'd32);
   assign _zz__zz_decode_RS2_2 = writeBack_MUL_LOW[31 : 0];
@@ -1572,10 +1562,9 @@ module VexRiscv (
   assign _zz_memory_DivPlugin_rs1_2 = {32'd0, _zz_memory_DivPlugin_rs1_3};
   assign _zz_memory_DivPlugin_rs2_2 = _zz_memory_DivPlugin_rs2;
   assign _zz_memory_DivPlugin_rs2_1 = {31'd0, _zz_memory_DivPlugin_rs2_2};
-  assign _zz_iBusWishbone_ADR_1 = (iBus_cmd_payload_address >>> 3'd5);
   assign _zz_decode_RegFilePlugin_rs1Data = 1'b1;
   assign _zz_decode_RegFilePlugin_rs2Data = 1'b1;
-  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_6 = {_zz_IBusCachedPlugin_jump_pcLoad_payload_4,_zz_IBusCachedPlugin_jump_pcLoad_payload_3};
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_6 = {_zz_IBusSimplePlugin_jump_pcLoad_payload_4,_zz_IBusSimplePlugin_jump_pcLoad_payload_3};
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_1 = dataCache_1_io_cpu_writeBack_address[1 : 0];
   assign _zz_writeBack_DBusCachedPlugin_rspShifted_3 = dataCache_1_io_cpu_writeBack_address[1 : 1];
   assign _zz_decode_LEGAL_INSTRUCTION = 32'h0000107f;
@@ -1601,20 +1590,20 @@ module VexRiscv (
   assign _zz_decode_LEGAL_INSTRUCTION_20 = 32'h00000073;
   assign _zz_decode_LEGAL_INSTRUCTION_21 = (decode_INSTRUCTION & 32'hffffffff);
   assign _zz_decode_LEGAL_INSTRUCTION_22 = 32'h10500073;
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_27 = {_zz_IBusCachedPlugin_decompressor_decompressed_12,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_28 = _zz_IBusCachedPlugin_decompressor_decompressed[5];
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_29 = _zz_IBusCachedPlugin_decompressor_decompressed[2];
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_31 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b01);
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_32 = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b11) && (_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5] == 2'b00));
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_33 = 7'h0;
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_34 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2];
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_35 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_36 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 7];
-  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
-  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[19 : 12];
-  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[20];
-  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_7 = decode_INSTRUCTION[31];
-  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_8 = decode_INSTRUCTION[7];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_27 = {_zz_IBusSimplePlugin_decompressor_decompressed_12,_zz_IBusSimplePlugin_decompressor_decompressed[4 : 3]};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_28 = _zz_IBusSimplePlugin_decompressor_decompressed[5];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_29 = _zz_IBusSimplePlugin_decompressor_decompressed[2];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_31 = (_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10] == 2'b01);
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_32 = ((_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10] == 2'b11) && (_zz_IBusSimplePlugin_decompressor_decompressed[6 : 5] == 2'b00));
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_33 = 7'h0;
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_34 = _zz_IBusSimplePlugin_decompressor_decompressed[6 : 2];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_35 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_36 = _zz_IBusSimplePlugin_decompressor_decompressed[11 : 7];
+  assign _zz_IBusSimplePlugin_predictionJumpInterface_payload_4 = decode_INSTRUCTION[31];
+  assign _zz_IBusSimplePlugin_predictionJumpInterface_payload_5 = decode_INSTRUCTION[19 : 12];
+  assign _zz_IBusSimplePlugin_predictionJumpInterface_payload_6 = decode_INSTRUCTION[20];
+  assign _zz_IBusSimplePlugin_predictionJumpInterface_payload_7 = decode_INSTRUCTION[31];
+  assign _zz_IBusSimplePlugin_predictionJumpInterface_payload_8 = decode_INSTRUCTION[7];
   assign _zz__zz_decode_IS_RS2_SIGNED = (decode_INSTRUCTION & 32'h02004064);
   assign _zz__zz_decode_IS_RS2_SIGNED_1 = 32'h02004020;
   assign _zz__zz_decode_IS_RS2_SIGNED_2 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
@@ -1759,7 +1748,7 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_148 = {_zz_decode_IS_RS2_SIGNED_3,(_zz__zz_decode_IS_RS2_SIGNED_149 == _zz__zz_decode_IS_RS2_SIGNED_150)};
   assign _zz__zz_decode_IS_RS2_SIGNED_152 = (|{_zz__zz_decode_IS_RS2_SIGNED_153,{_zz__zz_decode_IS_RS2_SIGNED_154,_zz__zz_decode_IS_RS2_SIGNED_156}});
   assign _zz__zz_decode_IS_RS2_SIGNED_158 = (|{_zz__zz_decode_IS_RS2_SIGNED_159,_zz__zz_decode_IS_RS2_SIGNED_160});
-  assign _zz__zz_decode_IS_RS2_SIGNED_163 = {(|_zz__zz_decode_IS_RS2_SIGNED_164),(|_zz__zz_decode_IS_RS2_SIGNED_167)};
+  assign _zz__zz_decode_IS_RS2_SIGNED_163 = (|{_zz__zz_decode_IS_RS2_SIGNED_164,_zz__zz_decode_IS_RS2_SIGNED_165});
   assign _zz__zz_decode_IS_RS2_SIGNED_117 = 32'h00000028;
   assign _zz__zz_decode_IS_RS2_SIGNED_139 = 32'h00000044;
   assign _zz__zz_decode_IS_RS2_SIGNED_141 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
@@ -1772,8 +1761,8 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_156 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_157) == 32'h40000030);
   assign _zz__zz_decode_IS_RS2_SIGNED_159 = _zz_decode_IS_RS2_SIGNED_2;
   assign _zz__zz_decode_IS_RS2_SIGNED_160 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_161 == _zz__zz_decode_IS_RS2_SIGNED_162)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_164 = {_zz_decode_IS_RS2_SIGNED_1,(_zz__zz_decode_IS_RS2_SIGNED_165 == _zz__zz_decode_IS_RS2_SIGNED_166)};
-  assign _zz__zz_decode_IS_RS2_SIGNED_167 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_168) == 32'h00001008);
+  assign _zz__zz_decode_IS_RS2_SIGNED_164 = _zz_decode_IS_RS2_SIGNED_1;
+  assign _zz__zz_decode_IS_RS2_SIGNED_165 = ((decode_INSTRUCTION & _zz__zz_decode_IS_RS2_SIGNED_166) == 32'h00000004);
   assign _zz__zz_decode_IS_RS2_SIGNED_143 = 32'h00005004;
   assign _zz__zz_decode_IS_RS2_SIGNED_145 = (decode_INSTRUCTION & 32'h00004050);
   assign _zz__zz_decode_IS_RS2_SIGNED_146 = 32'h00004000;
@@ -1781,9 +1770,7 @@ module VexRiscv (
   assign _zz__zz_decode_IS_RS2_SIGNED_157 = 32'h40000034;
   assign _zz__zz_decode_IS_RS2_SIGNED_161 = (decode_INSTRUCTION & 32'h00002014);
   assign _zz__zz_decode_IS_RS2_SIGNED_162 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_165 = (decode_INSTRUCTION & 32'h0000004c);
-  assign _zz__zz_decode_IS_RS2_SIGNED_166 = 32'h00000004;
-  assign _zz__zz_decode_IS_RS2_SIGNED_168 = 32'h00005048;
+  assign _zz__zz_decode_IS_RS2_SIGNED_166 = 32'h0000004c;
   assign _zz_execute_BranchPlugin_branch_src2_6 = execute_INSTRUCTION[31];
   assign _zz_execute_BranchPlugin_branch_src2_7 = execute_INSTRUCTION[19 : 12];
   assign _zz_execute_BranchPlugin_branch_src2_8 = execute_INSTRUCTION[20];
@@ -1808,47 +1795,20 @@ module VexRiscv (
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache (
-    .io_flush                              (IBusCachedPlugin_cache_io_flush                           ), //i
-    .io_cpu_prefetch_isValid               (IBusCachedPlugin_cache_io_cpu_prefetch_isValid            ), //i
-    .io_cpu_prefetch_haltIt                (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt             ), //o
-    .io_cpu_prefetch_pc                    (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]     ), //i
-    .io_cpu_fetch_isValid                  (IBusCachedPlugin_cache_io_cpu_fetch_isValid               ), //i
-    .io_cpu_fetch_isStuck                  (IBusCachedPlugin_cache_io_cpu_fetch_isStuck               ), //i
-    .io_cpu_fetch_isRemoved                (IBusCachedPlugin_cache_io_cpu_fetch_isRemoved             ), //i
-    .io_cpu_fetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]     ), //i
-    .io_cpu_fetch_data                     (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]            ), //o
-    .io_cpu_fetch_mmuRsp_physicalAddress   (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]         ), //i
-    .io_cpu_fetch_mmuRsp_isIoAccess        (IBusCachedPlugin_mmuBus_rsp_isIoAccess                    ), //i
-    .io_cpu_fetch_mmuRsp_isPaging          (IBusCachedPlugin_mmuBus_rsp_isPaging                      ), //i
-    .io_cpu_fetch_mmuRsp_allowRead         (IBusCachedPlugin_mmuBus_rsp_allowRead                     ), //i
-    .io_cpu_fetch_mmuRsp_allowWrite        (IBusCachedPlugin_mmuBus_rsp_allowWrite                    ), //i
-    .io_cpu_fetch_mmuRsp_allowExecute      (IBusCachedPlugin_mmuBus_rsp_allowExecute                  ), //i
-    .io_cpu_fetch_mmuRsp_exception         (IBusCachedPlugin_mmuBus_rsp_exception                     ), //i
-    .io_cpu_fetch_mmuRsp_refilling         (IBusCachedPlugin_mmuBus_rsp_refilling                     ), //i
-    .io_cpu_fetch_mmuRsp_bypassTranslation (IBusCachedPlugin_mmuBus_rsp_bypassTranslation             ), //i
-    .io_cpu_fetch_physicalAddress          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //o
-    .io_cpu_fetch_cacheMiss                (IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss             ), //o
-    .io_cpu_fetch_error                    (IBusCachedPlugin_cache_io_cpu_fetch_error                 ), //o
-    .io_cpu_fetch_mmuRefilling             (IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling          ), //o
-    .io_cpu_fetch_mmuException             (IBusCachedPlugin_cache_io_cpu_fetch_mmuException          ), //o
-    .io_cpu_fetch_isUser                   (IBusCachedPlugin_cache_io_cpu_fetch_isUser                ), //i
-    .io_cpu_decode_isValid                 (IBusCachedPlugin_cache_io_cpu_decode_isValid              ), //i
-    .io_cpu_decode_isStuck                 (IBusCachedPlugin_cache_io_cpu_decode_isStuck              ), //i
-    .io_cpu_decode_pc                      (IBusCachedPlugin_cache_io_cpu_decode_pc[31:0]             ), //i
-    .io_cpu_decode_physicalAddress         (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]), //o
-    .io_cpu_decode_data                    (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]           ), //o
-    .io_cpu_fill_valid                     (IBusCachedPlugin_cache_io_cpu_fill_valid                  ), //i
-    .io_cpu_fill_payload                   (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0] ), //i
-    .io_mem_cmd_valid                      (IBusCachedPlugin_cache_io_mem_cmd_valid                   ), //o
-    .io_mem_cmd_ready                      (iBus_cmd_ready                                            ), //i
-    .io_mem_cmd_payload_address            (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]   ), //o
-    .io_mem_cmd_payload_size               (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]       ), //o
-    .io_mem_rsp_valid                      (iBus_rsp_valid                                            ), //i
-    .io_mem_rsp_payload_data               (iBus_rsp_payload_data[31:0]                               ), //i
-    .io_mem_rsp_payload_error              (iBus_rsp_payload_error                                    ), //i
-    .clk                                   (clk                                                       ), //i
-    .reset                                 (reset                                                     )  //i
+  StreamFifoLowLatency IBusSimplePlugin_rspJoin_rspBuffer_c (
+    .io_push_valid         (iBus_rsp_toStream_valid                                       ), //i
+    .io_push_ready         (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready            ), //o
+    .io_push_payload_error (iBus_rsp_toStream_payload_error                               ), //i
+    .io_push_payload_inst  (iBus_rsp_toStream_payload_inst[31:0]                          ), //i
+    .io_pop_valid          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid             ), //o
+    .io_pop_ready          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready             ), //i
+    .io_pop_payload_error  (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error     ), //o
+    .io_pop_payload_inst   (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]), //o
+    .io_flush              (1'b0                                                          ), //i
+    .io_occupancy          (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy             ), //o
+    .io_availability       (IBusSimplePlugin_rspJoin_rspBuffer_c_io_availability          ), //o
+    .clk                   (clk                                                           ), //i
+    .reset                 (reset                                                         )  //i
   );
   DataCache dataCache_1 (
     .io_cpu_execute_isValid                 (dataCache_1_io_cpu_execute_isValid               ), //i
@@ -1902,7 +1862,7 @@ module VexRiscv (
     .io_cpu_flush_valid                     (dataCache_1_io_cpu_flush_valid                   ), //i
     .io_cpu_flush_ready                     (dataCache_1_io_cpu_flush_ready                   ), //o
     .io_cpu_flush_payload_singleLine        (dataCache_1_io_cpu_flush_payload_singleLine      ), //i
-    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[6:0]     ), //i
+    .io_cpu_flush_payload_lineId            (dataCache_1_io_cpu_flush_payload_lineId[4:0]     ), //i
     .io_cpu_writesPending                   (dataCache_1_io_cpu_writesPending                 ), //o
     .io_mem_cmd_valid                       (dataCache_1_io_mem_cmd_valid                     ), //o
     .io_mem_cmd_ready                       (toplevel_dataCache_1_io_mem_cmd_rValidN          ), //i
@@ -1921,11 +1881,11 @@ module VexRiscv (
     .reset                                  (reset                                            )  //i
   );
   always @(*) begin
-    case(_zz_IBusCachedPlugin_jump_pcLoad_payload_6)
-      2'b00 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
-      2'b01 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
-      2'b10 : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
-      default : _zz_IBusCachedPlugin_jump_pcLoad_payload_5 = IBusCachedPlugin_predictionJumpInterface_payload;
+    case(_zz_IBusSimplePlugin_jump_pcLoad_payload_6)
+      2'b00 : _zz_IBusSimplePlugin_jump_pcLoad_payload_5 = DBusCachedPlugin_redoBranch_payload;
+      2'b01 : _zz_IBusSimplePlugin_jump_pcLoad_payload_5 = CsrPlugin_jumpInterface_payload;
+      2'b10 : _zz_IBusSimplePlugin_jump_pcLoad_payload_5 = BranchPlugin_jumpInterface_payload;
+      default : _zz_IBusSimplePlugin_jump_pcLoad_payload_5 = IBusSimplePlugin_predictionJumpInterface_payload;
     endcase
   end
 
@@ -2665,33 +2625,33 @@ module VexRiscv (
   assign execute_MEMORY_STORE_DATA_RF = _zz_execute_MEMORY_STORE_DATA_RF;
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign decode_PREDICTION_HAD_BRANCHED1 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_PREDICTION_HAD_BRANCHED1 = IBusSimplePlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[34];
-  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[33];
-  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[32];
+  assign decode_IS_RS2_SIGNED = _zz_decode_IS_RS2_SIGNED[33];
+  assign decode_IS_RS1_SIGNED = _zz_decode_IS_RS2_SIGNED[32];
+  assign decode_IS_DIV = _zz_decode_IS_RS2_SIGNED[31];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[31];
+  assign decode_IS_MUL = _zz_decode_IS_RS2_SIGNED[30];
   assign _zz_memory_to_writeBack_ENV_CTRL = _zz_memory_to_writeBack_ENV_CTRL_1;
   assign _zz_execute_to_memory_ENV_CTRL = _zz_execute_to_memory_ENV_CTRL_1;
   assign decode_ENV_CTRL = _zz_decode_ENV_CTRL;
   assign _zz_decode_to_execute_ENV_CTRL = _zz_decode_to_execute_ENV_CTRL_1;
-  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[27];
+  assign decode_IS_CSR = _zz_decode_IS_RS2_SIGNED[26];
   assign _zz_decode_to_execute_BRANCH_CTRL = _zz_decode_to_execute_BRANCH_CTRL_1;
   assign _zz_execute_to_memory_SHIFT_CTRL = _zz_execute_to_memory_SHIFT_CTRL_1;
   assign decode_SHIFT_CTRL = _zz_decode_SHIFT_CTRL;
   assign _zz_decode_to_execute_SHIFT_CTRL = _zz_decode_to_execute_SHIFT_CTRL_1;
   assign decode_ALU_BITWISE_CTRL = _zz_decode_ALU_BITWISE_CTRL;
   assign _zz_decode_to_execute_ALU_BITWISE_CTRL = _zz_decode_to_execute_ALU_BITWISE_CTRL_1;
-  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[20];
-  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[19];
+  assign decode_SRC_LESS_UNSIGNED = _zz_decode_IS_RS2_SIGNED[19];
+  assign decode_MEMORY_MANAGMENT = _zz_decode_IS_RS2_SIGNED[18];
   assign memory_MEMORY_LRSC = execute_to_memory_MEMORY_LRSC;
   assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[13];
+  assign decode_MEMORY_WR = _zz_decode_IS_RS2_SIGNED[12];
   assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[12];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_decode_IS_RS2_SIGNED[11];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_decode_IS_RS2_SIGNED[10];
   assign decode_SRC2_CTRL = _zz_decode_SRC2_CTRL;
   assign _zz_decode_to_execute_SRC2_CTRL = _zz_decode_to_execute_SRC2_CTRL_1;
   assign decode_ALU_CTRL = _zz_decode_ALU_CTRL;
@@ -2726,8 +2686,8 @@ module VexRiscv (
   assign execute_BRANCH_COND_RESULT = _zz_execute_BRANCH_COND_RESULT_1;
   assign execute_PREDICTION_HAD_BRANCHED1 = decode_to_execute_PREDICTION_HAD_BRANCHED1;
   assign execute_BRANCH_CTRL = _zz_execute_BRANCH_CTRL;
-  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[17];
-  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[5];
+  assign decode_RS2_USE = _zz_decode_IS_RS2_SIGNED[16];
+  assign decode_RS1_USE = _zz_decode_IS_RS2_SIGNED[4];
   always @(*) begin
     _zz_decode_RS2 = execute_REGFILE_WRITE_DATA;
     if(when_CsrPlugin_l1587) begin
@@ -2830,8 +2790,8 @@ module VexRiscv (
   assign execute_SRC2_CTRL = _zz_execute_SRC2_CTRL;
   assign execute_IS_RVC = decode_to_execute_IS_RVC;
   assign execute_SRC1_CTRL = _zz_execute_SRC1_CTRL;
-  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[3];
-  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[18];
+  assign decode_SRC_USE_SUB_LESS = _zz_decode_IS_RS2_SIGNED[2];
+  assign decode_SRC_ADD_ZERO = _zz_decode_IS_RS2_SIGNED[17];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
   assign execute_ALU_CTRL = _zz_execute_ALU_CTRL;
@@ -2847,9 +2807,9 @@ module VexRiscv (
     end
   end
 
-  assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_decompressor_output_payload_rsp_inst);
+  assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusSimplePlugin_decompressor_output_payload_rsp_inst);
   always @(*) begin
-    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[10];
+    decode_REGFILE_WRITE_VALID = _zz_decode_IS_RS2_SIGNED[9];
     if(when_RegFilePlugin_l63) begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
@@ -2890,38 +2850,9 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_AMO = _zz_decode_IS_RS2_SIGNED[16];
-  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[15];
-  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[4];
-  assign decode_FLUSH_ALL = _zz_decode_IS_RS2_SIGNED[0];
-  always @(*) begin
-    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(when_IBusCachedPlugin_l262) begin
-      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(when_IBusCachedPlugin_l256) begin
-      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(when_IBusCachedPlugin_l250) begin
-      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(when_IBusCachedPlugin_l245) begin
-      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
-    end
-  end
-
+  assign decode_MEMORY_AMO = _zz_decode_IS_RS2_SIGNED[15];
+  assign decode_MEMORY_LRSC = _zz_decode_IS_RS2_SIGNED[14];
+  assign decode_MEMORY_ENABLE = _zz_decode_IS_RS2_SIGNED[3];
   assign decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_1;
   always @(*) begin
     _zz_memory_to_writeBack_FORMAL_PC_NEXT = memory_FORMAL_PC_NEXT;
@@ -2932,14 +2863,14 @@ module VexRiscv (
 
   always @(*) begin
     _zz_decode_to_execute_FORMAL_PC_NEXT = decode_FORMAL_PC_NEXT;
-    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
-      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusCachedPlugin_predictionJumpInterface_payload;
+    if(IBusSimplePlugin_predictionJumpInterface_valid) begin
+      _zz_decode_to_execute_FORMAL_PC_NEXT = IBusSimplePlugin_predictionJumpInterface_payload;
     end
   end
 
-  assign decode_PC = IBusCachedPlugin_decodePc_pcReg;
-  assign decode_INSTRUCTION = IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
-  assign decode_IS_RVC = IBusCachedPlugin_injector_decodeInput_payload_isRvc;
+  assign decode_PC = IBusSimplePlugin_decodePc_pcReg;
+  assign decode_INSTRUCTION = IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  assign decode_IS_RVC = IBusSimplePlugin_injector_decodeInput_payload_isRvc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @(*) begin
@@ -2964,7 +2895,7 @@ module VexRiscv (
 
   always @(*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_when) begin
+    if(decodeExceptionPort_valid) begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed) begin
@@ -2975,10 +2906,10 @@ module VexRiscv (
   assign decode_arbitration_flushIt = 1'b0;
   always @(*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(IBusCachedPlugin_predictionJumpInterface_valid) begin
+    if(IBusSimplePlugin_predictionJumpInterface_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_when) begin
+    if(decodeExceptionPort_valid) begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
@@ -3096,26 +3027,26 @@ module VexRiscv (
   assign lastStageIsValid = writeBack_arbitration_isValid;
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @(*) begin
-    IBusCachedPlugin_fetcherHalt = 1'b0;
+    IBusSimplePlugin_fetcherHalt = 1'b0;
     if(when_CsrPlugin_l1272) begin
-      IBusCachedPlugin_fetcherHalt = 1'b1;
+      IBusSimplePlugin_fetcherHalt = 1'b1;
     end
     if(when_CsrPlugin_l1390) begin
-      IBusCachedPlugin_fetcherHalt = 1'b1;
+      IBusSimplePlugin_fetcherHalt = 1'b1;
     end
     if(when_CsrPlugin_l1456) begin
-      IBusCachedPlugin_fetcherHalt = 1'b1;
+      IBusSimplePlugin_fetcherHalt = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_forceNoDecodeCond = 1'b0;
+  assign IBusSimplePlugin_forceNoDecodeCond = 1'b0;
   always @(*) begin
-    IBusCachedPlugin_incomingInstruction = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_valid) begin
-      IBusCachedPlugin_incomingInstruction = 1'b1;
+    IBusSimplePlugin_incomingInstruction = 1'b0;
+    if(IBusSimplePlugin_iBusRsp_stages_1_input_valid) begin
+      IBusSimplePlugin_incomingInstruction = 1'b1;
     end
-    if(IBusCachedPlugin_injector_decodeInput_valid) begin
-      IBusCachedPlugin_incomingInstruction = 1'b1;
+    if(IBusSimplePlugin_injector_decodeInput_valid) begin
+      IBusSimplePlugin_incomingInstruction = 1'b1;
     end
   end
 
@@ -3171,304 +3102,272 @@ module VexRiscv (
   assign CsrPlugin_allowException = 1'b1;
   assign CsrPlugin_allowEbreakException = 1'b1;
   assign CsrPlugin_xretAwayFromMachine = 1'b0;
-  assign IBusCachedPlugin_externalFlush = (|{writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}});
-  assign IBusCachedPlugin_jump_pcLoad_valid = (|{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}});
-  assign _zz_IBusCachedPlugin_jump_pcLoad_payload = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_1 = (_zz_IBusCachedPlugin_jump_pcLoad_payload & (~ _zz__zz_IBusCachedPlugin_jump_pcLoad_payload_1));
-  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_2 = _zz_IBusCachedPlugin_jump_pcLoad_payload_1[3];
-  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_3 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[1] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
-  assign _zz_IBusCachedPlugin_jump_pcLoad_payload_4 = (_zz_IBusCachedPlugin_jump_pcLoad_payload_1[2] || _zz_IBusCachedPlugin_jump_pcLoad_payload_2);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_IBusCachedPlugin_jump_pcLoad_payload_5;
+  assign IBusSimplePlugin_externalFlush = (|{writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}});
+  assign IBusSimplePlugin_jump_pcLoad_valid = (|{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusSimplePlugin_predictionJumpInterface_valid}}});
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload = {IBusSimplePlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_1 = (_zz_IBusSimplePlugin_jump_pcLoad_payload & (~ _zz__zz_IBusSimplePlugin_jump_pcLoad_payload_1));
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_2 = _zz_IBusSimplePlugin_jump_pcLoad_payload_1[3];
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_3 = (_zz_IBusSimplePlugin_jump_pcLoad_payload_1[1] || _zz_IBusSimplePlugin_jump_pcLoad_payload_2);
+  assign _zz_IBusSimplePlugin_jump_pcLoad_payload_4 = (_zz_IBusSimplePlugin_jump_pcLoad_payload_1[2] || _zz_IBusSimplePlugin_jump_pcLoad_payload_2);
+  assign IBusSimplePlugin_jump_pcLoad_payload = _zz_IBusSimplePlugin_jump_pcLoad_payload_5;
   always @(*) begin
-    IBusCachedPlugin_fetchPc_correction = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid) begin
-      IBusCachedPlugin_fetchPc_correction = 1'b1;
-    end
-    if(IBusCachedPlugin_jump_pcLoad_valid) begin
-      IBusCachedPlugin_fetchPc_correction = 1'b1;
+    IBusSimplePlugin_fetchPc_correction = 1'b0;
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
+      IBusSimplePlugin_fetchPc_correction = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_fetchPc_output_fire = (IBusCachedPlugin_fetchPc_output_valid && IBusCachedPlugin_fetchPc_output_ready);
-  assign IBusCachedPlugin_fetchPc_corrected = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_correctionReg);
+  assign IBusSimplePlugin_fetchPc_output_fire = (IBusSimplePlugin_fetchPc_output_valid && IBusSimplePlugin_fetchPc_output_ready);
+  assign IBusSimplePlugin_fetchPc_corrected = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_correctionReg);
   always @(*) begin
-    IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b0;
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
-      IBusCachedPlugin_fetchPc_pcRegPropagate = 1'b1;
+    IBusSimplePlugin_fetchPc_pcRegPropagate = 1'b0;
+    if(IBusSimplePlugin_iBusRsp_stages_1_input_ready) begin
+      IBusSimplePlugin_fetchPc_pcRegPropagate = 1'b1;
     end
   end
 
-  assign when_Fetcher_l133 = (IBusCachedPlugin_fetchPc_correction || IBusCachedPlugin_fetchPc_pcRegPropagate);
-  assign when_Fetcher_l133_1 = ((! IBusCachedPlugin_fetchPc_output_valid) && IBusCachedPlugin_fetchPc_output_ready);
+  assign when_Fetcher_l133 = (IBusSimplePlugin_fetchPc_correction || IBusSimplePlugin_fetchPc_pcRegPropagate);
+  assign when_Fetcher_l133_1 = ((! IBusSimplePlugin_fetchPc_output_valid) && IBusSimplePlugin_fetchPc_output_ready);
   always @(*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_IBusCachedPlugin_fetchPc_pc);
-    if(IBusCachedPlugin_fetchPc_inc) begin
-      IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
+    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_IBusSimplePlugin_fetchPc_pc);
+    if(IBusSimplePlugin_fetchPc_inc) begin
+      IBusSimplePlugin_fetchPc_pc[1] = 1'b0;
     end
-    if(IBusCachedPlugin_fetchPc_redo_valid) begin
-      IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
+      IBusSimplePlugin_fetchPc_pc = IBusSimplePlugin_jump_pcLoad_payload;
     end
-    if(IBusCachedPlugin_jump_pcLoad_valid) begin
-      IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_jump_pcLoad_payload;
-    end
-    IBusCachedPlugin_fetchPc_pc[0] = 1'b0;
+    IBusSimplePlugin_fetchPc_pc[0] = 1'b0;
   end
 
   always @(*) begin
-    IBusCachedPlugin_fetchPc_flushed = 1'b0;
-    if(IBusCachedPlugin_fetchPc_redo_valid) begin
-      IBusCachedPlugin_fetchPc_flushed = 1'b1;
-    end
-    if(IBusCachedPlugin_jump_pcLoad_valid) begin
-      IBusCachedPlugin_fetchPc_flushed = 1'b1;
+    IBusSimplePlugin_fetchPc_flushed = 1'b0;
+    if(IBusSimplePlugin_jump_pcLoad_valid) begin
+      IBusSimplePlugin_fetchPc_flushed = 1'b1;
     end
   end
 
-  assign when_Fetcher_l160 = (IBusCachedPlugin_fetchPc_booted && ((IBusCachedPlugin_fetchPc_output_ready || IBusCachedPlugin_fetchPc_correction) || IBusCachedPlugin_fetchPc_pcRegPropagate));
-  assign IBusCachedPlugin_fetchPc_output_valid = ((! IBusCachedPlugin_fetcherHalt) && IBusCachedPlugin_fetchPc_booted);
-  assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
+  assign when_Fetcher_l160 = (IBusSimplePlugin_fetchPc_booted && ((IBusSimplePlugin_fetchPc_output_ready || IBusSimplePlugin_fetchPc_correction) || IBusSimplePlugin_fetchPc_pcRegPropagate));
+  assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
+  assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
   always @(*) begin
-    IBusCachedPlugin_decodePc_flushed = 1'b0;
+    IBusSimplePlugin_decodePc_flushed = 1'b0;
     if(when_Fetcher_l194) begin
-      IBusCachedPlugin_decodePc_flushed = 1'b1;
+      IBusSimplePlugin_decodePc_flushed = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_IBusCachedPlugin_decodePc_pcPlus);
-  assign IBusCachedPlugin_decodePc_injectedDecode = 1'b0;
-  assign when_Fetcher_l182 = (decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode));
-  assign when_Fetcher_l194 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
+  assign IBusSimplePlugin_decodePc_pcPlus = (IBusSimplePlugin_decodePc_pcReg + _zz_IBusSimplePlugin_decodePc_pcPlus);
+  assign IBusSimplePlugin_decodePc_injectedDecode = 1'b0;
+  assign when_Fetcher_l182 = (decode_arbitration_isFiring && (! IBusSimplePlugin_decodePc_injectedDecode));
+  assign when_Fetcher_l194 = (IBusSimplePlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
+  assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_valid = IBusSimplePlugin_fetchPc_output_valid;
+  assign IBusSimplePlugin_fetchPc_output_ready = IBusSimplePlugin_iBusRsp_stages_0_input_ready;
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_payload = IBusSimplePlugin_fetchPc_output_payload;
   always @(*) begin
-    IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
-    if(IBusCachedPlugin_rsp_redoFetch) begin
-      IBusCachedPlugin_iBusRsp_redoFetch = 1'b1;
+    IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b0;
+    if(when_IBusSimplePlugin_l305) begin
+      IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_valid = IBusCachedPlugin_fetchPc_output_valid;
-  assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_IBusSimplePlugin_iBusRsp_stages_0_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_payload = IBusSimplePlugin_iBusRsp_stages_0_input_payload;
+  assign IBusSimplePlugin_iBusRsp_stages_1_halt = 1'b0;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
+  assign IBusSimplePlugin_iBusRsp_flush = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_iBusRsp_redoFetch);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready;
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_payload = IBusSimplePlugin_fetchPc_pcReg;
   always @(*) begin
-    IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_prefetch_haltIt) begin
-      IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b1;
+    IBusSimplePlugin_iBusRsp_readyForError = 1'b1;
+    if(IBusSimplePlugin_injector_decodeInput_valid) begin
+      IBusSimplePlugin_iBusRsp_readyForError = 1'b0;
     end
   end
 
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_0_input_ready);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
+  assign IBusSimplePlugin_decompressor_input_valid = (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_iBusRsp_redoFetch));
+  assign IBusSimplePlugin_decompressor_input_payload_pc = IBusSimplePlugin_iBusRsp_output_payload_pc;
+  assign IBusSimplePlugin_decompressor_input_payload_rsp_error = IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
+  assign IBusSimplePlugin_decompressor_input_payload_rsp_inst = IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
+  assign IBusSimplePlugin_decompressor_input_payload_isRvc = IBusSimplePlugin_iBusRsp_output_payload_isRvc;
+  assign IBusSimplePlugin_iBusRsp_output_ready = IBusSimplePlugin_decompressor_input_ready;
+  assign IBusSimplePlugin_decompressor_flushNext = 1'b0;
+  assign IBusSimplePlugin_decompressor_consumeCurrent = 1'b0;
+  assign IBusSimplePlugin_decompressor_isInputLowRvc = (IBusSimplePlugin_decompressor_input_payload_rsp_inst[1 : 0] != 2'b11);
+  assign IBusSimplePlugin_decompressor_isInputHighRvc = (IBusSimplePlugin_decompressor_input_payload_rsp_inst[17 : 16] != 2'b11);
+  assign IBusSimplePlugin_decompressor_throw2Bytes = (IBusSimplePlugin_decompressor_throw2BytesReg || IBusSimplePlugin_decompressor_input_payload_pc[1]);
+  assign IBusSimplePlugin_decompressor_unaligned = (IBusSimplePlugin_decompressor_throw2Bytes || IBusSimplePlugin_decompressor_bufferValid);
+  assign IBusSimplePlugin_decompressor_bufferValidPatched = (IBusSimplePlugin_decompressor_input_valid ? IBusSimplePlugin_decompressor_bufferValid : IBusSimplePlugin_decompressor_bufferValidLatch);
+  assign IBusSimplePlugin_decompressor_throw2BytesPatched = (IBusSimplePlugin_decompressor_input_valid ? IBusSimplePlugin_decompressor_throw2Bytes : IBusSimplePlugin_decompressor_throw2BytesLatch);
+  assign IBusSimplePlugin_decompressor_raw = (IBusSimplePlugin_decompressor_bufferValidPatched ? {IBusSimplePlugin_decompressor_input_payload_rsp_inst[15 : 0],IBusSimplePlugin_decompressor_bufferData} : {IBusSimplePlugin_decompressor_input_payload_rsp_inst[31 : 16],(IBusSimplePlugin_decompressor_throw2BytesPatched ? IBusSimplePlugin_decompressor_input_payload_rsp_inst[31 : 16] : IBusSimplePlugin_decompressor_input_payload_rsp_inst[15 : 0])});
+  assign IBusSimplePlugin_decompressor_isRvc = (IBusSimplePlugin_decompressor_raw[1 : 0] != 2'b11);
+  assign _zz_IBusSimplePlugin_decompressor_decompressed = IBusSimplePlugin_decompressor_raw[15 : 0];
   always @(*) begin
-    IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_mmuBus_busy) begin
-      IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
-    end
-    if(when_IBusCachedPlugin_l273) begin
-      IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
-    end
-  end
-
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
-  always @(*) begin
-    IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-    if(IBusCachedPlugin_decompressor_throw2BytesReg) begin
-      IBusCachedPlugin_fetchPc_redo_payload[1] = 1'b1;
-    end
-  end
-
-  assign IBusCachedPlugin_iBusRsp_flush = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready;
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready = ((1'b0 && (! _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  always @(*) begin
-    IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
-    if(IBusCachedPlugin_injector_decodeInput_valid) begin
-      IBusCachedPlugin_iBusRsp_readyForError = 1'b0;
-    end
-  end
-
-  assign IBusCachedPlugin_decompressor_input_valid = (IBusCachedPlugin_iBusRsp_output_valid && (! IBusCachedPlugin_iBusRsp_redoFetch));
-  assign IBusCachedPlugin_decompressor_input_payload_pc = IBusCachedPlugin_iBusRsp_output_payload_pc;
-  assign IBusCachedPlugin_decompressor_input_payload_rsp_error = IBusCachedPlugin_iBusRsp_output_payload_rsp_error;
-  assign IBusCachedPlugin_decompressor_input_payload_rsp_inst = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
-  assign IBusCachedPlugin_decompressor_input_payload_isRvc = IBusCachedPlugin_iBusRsp_output_payload_isRvc;
-  assign IBusCachedPlugin_iBusRsp_output_ready = IBusCachedPlugin_decompressor_input_ready;
-  assign IBusCachedPlugin_decompressor_flushNext = 1'b0;
-  assign IBusCachedPlugin_decompressor_consumeCurrent = 1'b0;
-  assign IBusCachedPlugin_decompressor_isInputLowRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[1 : 0] != 2'b11);
-  assign IBusCachedPlugin_decompressor_isInputHighRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[17 : 16] != 2'b11);
-  assign IBusCachedPlugin_decompressor_throw2Bytes = (IBusCachedPlugin_decompressor_throw2BytesReg || IBusCachedPlugin_decompressor_input_payload_pc[1]);
-  assign IBusCachedPlugin_decompressor_unaligned = (IBusCachedPlugin_decompressor_throw2Bytes || IBusCachedPlugin_decompressor_bufferValid);
-  assign IBusCachedPlugin_decompressor_bufferValidPatched = (IBusCachedPlugin_decompressor_input_valid ? IBusCachedPlugin_decompressor_bufferValid : IBusCachedPlugin_decompressor_bufferValidLatch);
-  assign IBusCachedPlugin_decompressor_throw2BytesPatched = (IBusCachedPlugin_decompressor_input_valid ? IBusCachedPlugin_decompressor_throw2Bytes : IBusCachedPlugin_decompressor_throw2BytesLatch);
-  assign IBusCachedPlugin_decompressor_raw = (IBusCachedPlugin_decompressor_bufferValidPatched ? {IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0],IBusCachedPlugin_decompressor_bufferData} : {IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16],(IBusCachedPlugin_decompressor_throw2BytesPatched ? IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16] : IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0])});
-  assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != 2'b11);
-  assign _zz_IBusCachedPlugin_decompressor_decompressed = IBusCachedPlugin_decompressor_raw[15 : 0];
-  always @(*) begin
-    IBusCachedPlugin_decompressor_decompressed = 32'h0;
+    IBusSimplePlugin_decompressor_decompressed = 32'h0;
     case(switch_Misc_l44)
       5'h0 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_IBusCachedPlugin_decompressor_decompressed[10 : 7]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 11]},_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00},5'h02},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h13};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_IBusSimplePlugin_decompressor_decompressed[10 : 7]},_zz_IBusSimplePlugin_decompressor_decompressed[12 : 11]},_zz_IBusSimplePlugin_decompressor_decompressed[5]},_zz_IBusSimplePlugin_decompressor_decompressed[6]},2'b00},5'h02},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed_2},7'h13};
         if(when_Misc_l47) begin
-          IBusCachedPlugin_decompressor_decompressed = 32'h0;
+          IBusSimplePlugin_decompressor_decompressed = 32'h0;
         end
       end
       5'h02 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_3,_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_2},7'h03};
+        IBusSimplePlugin_decompressor_decompressed = {{{{_zz_IBusSimplePlugin_decompressor_decompressed_3,_zz_IBusSimplePlugin_decompressor_decompressed_1},3'b010},_zz_IBusSimplePlugin_decompressor_decompressed_2},7'h03};
       end
       5'h06 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_3[11 : 5],_zz_IBusCachedPlugin_decompressor_decompressed_2},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_3[4 : 0]},7'h23};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_3[11 : 5],_zz_IBusSimplePlugin_decompressor_decompressed_2},_zz_IBusSimplePlugin_decompressor_decompressed_1},3'b010},_zz_IBusSimplePlugin_decompressor_decompressed_3[4 : 0]},7'h23};
       end
       5'h08 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
+        IBusSimplePlugin_decompressor_decompressed = {{{{_zz_IBusSimplePlugin_decompressor_decompressed_5,_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h09 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_8[20],_zz_IBusCachedPlugin_decompressor_decompressed_8[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_8[11]},_zz_IBusCachedPlugin_decompressor_decompressed_8[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_20},7'h6f};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_8[20],_zz_IBusSimplePlugin_decompressor_decompressed_8[10 : 1]},_zz_IBusSimplePlugin_decompressor_decompressed_8[11]},_zz_IBusSimplePlugin_decompressor_decompressed_8[19 : 12]},_zz_IBusSimplePlugin_decompressor_decompressed_20},7'h6f};
       end
       5'h0a : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_IBusCachedPlugin_decompressor_decompressed_5,5'h0},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
+        IBusSimplePlugin_decompressor_decompressed = {{{{_zz_IBusSimplePlugin_decompressor_decompressed_5,5'h0},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h0b : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7] == 5'h02) ? {{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_27,_zz_IBusCachedPlugin_decompressor_decompressed_28},_zz_IBusCachedPlugin_decompressor_decompressed_29},_zz_IBusCachedPlugin_decompressor_decompressed[6]},4'b0000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13} : {{_zz_IBusCachedPlugin_decompressor_decompressed_30[31 : 12],_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h37});
+        IBusSimplePlugin_decompressor_decompressed = ((_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7] == 5'h02) ? {{{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_27,_zz_IBusSimplePlugin_decompressor_decompressed_28},_zz_IBusSimplePlugin_decompressor_decompressed_29},_zz_IBusSimplePlugin_decompressor_decompressed[6]},4'b0000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h13} : {{_zz_IBusSimplePlugin_decompressor_decompressed_30[31 : 12],_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h37});
       end
       5'h0c : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusCachedPlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusCachedPlugin_decompressor_decompressed_31 || _zz_IBusCachedPlugin_decompressor_decompressed_32)},5'h0}),(((! _zz_IBusCachedPlugin_decompressor_decompressed[11]) || _zz_IBusCachedPlugin_decompressor_decompressed_22) ? _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] : _zz_IBusCachedPlugin_decompressor_decompressed_2)},_zz_IBusCachedPlugin_decompressor_decompressed_1},_zz_IBusCachedPlugin_decompressor_decompressed_24},_zz_IBusCachedPlugin_decompressor_decompressed_1},(_zz_IBusCachedPlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{((_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10] == 2'b10) ? _zz_IBusSimplePlugin_decompressor_decompressed_26 : {{1'b0,(_zz_IBusSimplePlugin_decompressor_decompressed_31 || _zz_IBusSimplePlugin_decompressor_decompressed_32)},5'h0}),(((! _zz_IBusSimplePlugin_decompressor_decompressed[11]) || _zz_IBusSimplePlugin_decompressor_decompressed_22) ? _zz_IBusSimplePlugin_decompressor_decompressed[6 : 2] : _zz_IBusSimplePlugin_decompressor_decompressed_2)},_zz_IBusSimplePlugin_decompressor_decompressed_1},_zz_IBusSimplePlugin_decompressor_decompressed_24},_zz_IBusSimplePlugin_decompressor_decompressed_1},(_zz_IBusSimplePlugin_decompressor_decompressed_22 ? 7'h13 : 7'h33)};
       end
       5'h0d : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_15[20],_zz_IBusCachedPlugin_decompressor_decompressed_15[10 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_15[11]},_zz_IBusCachedPlugin_decompressor_decompressed_15[19 : 12]},_zz_IBusCachedPlugin_decompressor_decompressed_19},7'h6f};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_15[20],_zz_IBusSimplePlugin_decompressor_decompressed_15[10 : 1]},_zz_IBusSimplePlugin_decompressor_decompressed_15[11]},_zz_IBusSimplePlugin_decompressor_decompressed_15[19 : 12]},_zz_IBusSimplePlugin_decompressor_decompressed_19},7'h6f};
       end
       5'h0e : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_18[12],_zz_IBusCachedPlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed_19},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_18[11]},7'h63};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_18[12],_zz_IBusSimplePlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusSimplePlugin_decompressor_decompressed_19},_zz_IBusSimplePlugin_decompressor_decompressed_1},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusSimplePlugin_decompressor_decompressed_18[11]},7'h63};
       end
       5'h0f : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_18[12],_zz_IBusCachedPlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed_19},_zz_IBusCachedPlugin_decompressor_decompressed_1},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusCachedPlugin_decompressor_decompressed_18[11]},7'h63};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_18[12],_zz_IBusSimplePlugin_decompressor_decompressed_18[10 : 5]},_zz_IBusSimplePlugin_decompressor_decompressed_19},_zz_IBusSimplePlugin_decompressor_decompressed_1},3'b001},_zz_IBusSimplePlugin_decompressor_decompressed_18[4 : 1]},_zz_IBusSimplePlugin_decompressor_decompressed_18[11]},7'h63};
       end
       5'h10 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h13};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{7'h0,_zz_IBusSimplePlugin_decompressor_decompressed[6 : 2]},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},3'b001},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h13};
       end
       5'h12 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_IBusCachedPlugin_decompressor_decompressed[3 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed[12]},_zz_IBusCachedPlugin_decompressor_decompressed[6 : 4]},2'b00},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h03};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_IBusSimplePlugin_decompressor_decompressed[3 : 2]},_zz_IBusSimplePlugin_decompressor_decompressed[12]},_zz_IBusSimplePlugin_decompressor_decompressed[6 : 4]},2'b00},_zz_IBusSimplePlugin_decompressor_decompressed_21},3'b010},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h03};
       end
       5'h14 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2] == 5'h0) ? {{{{12'h0,_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusCachedPlugin_decompressor_decompressed[12] ? _zz_IBusCachedPlugin_decompressor_decompressed_20 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_33,_zz_IBusCachedPlugin_decompressor_decompressed_34},(_zz_IBusCachedPlugin_decompressor_decompressed_35 ? _zz_IBusCachedPlugin_decompressor_decompressed_36 : _zz_IBusCachedPlugin_decompressor_decompressed_19)},3'b000},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 7]},7'h33}));
+        IBusSimplePlugin_decompressor_decompressed = ((_zz_IBusSimplePlugin_decompressor_decompressed[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_IBusSimplePlugin_decompressor_decompressed[6 : 2] == 5'h0) ? {{{{12'h0,_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},3'b000},(_zz_IBusSimplePlugin_decompressor_decompressed[12] ? _zz_IBusSimplePlugin_decompressor_decompressed_20 : _zz_IBusSimplePlugin_decompressor_decompressed_19)},7'h67} : {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_33,_zz_IBusSimplePlugin_decompressor_decompressed_34},(_zz_IBusSimplePlugin_decompressor_decompressed_35 ? _zz_IBusSimplePlugin_decompressor_decompressed_36 : _zz_IBusSimplePlugin_decompressor_decompressed_19)},3'b000},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 7]},7'h33}));
       end
       5'h16 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_37[11 : 5],_zz_IBusCachedPlugin_decompressor_decompressed[6 : 2]},_zz_IBusCachedPlugin_decompressor_decompressed_21},3'b010},_zz_IBusCachedPlugin_decompressor_decompressed_38[4 : 0]},7'h23};
+        IBusSimplePlugin_decompressor_decompressed = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_37[11 : 5],_zz_IBusSimplePlugin_decompressor_decompressed[6 : 2]},_zz_IBusSimplePlugin_decompressor_decompressed_21},3'b010},_zz_IBusSimplePlugin_decompressor_decompressed_38[4 : 0]},7'h23};
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_1 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[9 : 7]};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_2 = {2'b01,_zz_IBusCachedPlugin_decompressor_decompressed[4 : 2]};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_3 = {{{{5'h0,_zz_IBusCachedPlugin_decompressor_decompressed[5]},_zz_IBusCachedPlugin_decompressor_decompressed[12 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},2'b00};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_4 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_1 = {2'b01,_zz_IBusSimplePlugin_decompressor_decompressed[9 : 7]};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_2 = {2'b01,_zz_IBusSimplePlugin_decompressor_decompressed[4 : 2]};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_3 = {{{{5'h0,_zz_IBusSimplePlugin_decompressor_decompressed[5]},_zz_IBusSimplePlugin_decompressor_decompressed[12 : 10]},_zz_IBusSimplePlugin_decompressor_decompressed[6]},2'b00};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_4 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
   always @(*) begin
-    _zz_IBusCachedPlugin_decompressor_decompressed_5[11] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
-    _zz_IBusCachedPlugin_decompressor_decompressed_5[10] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
-    _zz_IBusCachedPlugin_decompressor_decompressed_5[9] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
-    _zz_IBusCachedPlugin_decompressor_decompressed_5[8] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
-    _zz_IBusCachedPlugin_decompressor_decompressed_5[7] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
-    _zz_IBusCachedPlugin_decompressor_decompressed_5[6] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
-    _zz_IBusCachedPlugin_decompressor_decompressed_5[5] = _zz_IBusCachedPlugin_decompressor_decompressed_4;
-    _zz_IBusCachedPlugin_decompressor_decompressed_5[4 : 0] = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 2];
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[11] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[10] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[9] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[8] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[7] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[6] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[5] = _zz_IBusSimplePlugin_decompressor_decompressed_4;
+    _zz_IBusSimplePlugin_decompressor_decompressed_5[4 : 0] = _zz_IBusSimplePlugin_decompressor_decompressed[6 : 2];
   end
 
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_6 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_6 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
   always @(*) begin
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[9] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[8] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[7] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[6] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[5] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[4] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[3] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[2] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[1] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
-    _zz_IBusCachedPlugin_decompressor_decompressed_7[0] = _zz_IBusCachedPlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[9] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[8] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[7] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[6] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[5] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[4] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[3] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[2] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[1] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
+    _zz_IBusSimplePlugin_decompressor_decompressed_7[0] = _zz_IBusSimplePlugin_decompressor_decompressed_6;
   end
 
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_8 = {{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_7,_zz_IBusCachedPlugin_decompressor_decompressed[8]},_zz_IBusCachedPlugin_decompressor_decompressed[10 : 9]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},_zz_IBusCachedPlugin_decompressor_decompressed[7]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11]},_zz_IBusCachedPlugin_decompressor_decompressed[5 : 3]},1'b0};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_9 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_8 = {{{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_7,_zz_IBusSimplePlugin_decompressor_decompressed[8]},_zz_IBusSimplePlugin_decompressor_decompressed[10 : 9]},_zz_IBusSimplePlugin_decompressor_decompressed[6]},_zz_IBusSimplePlugin_decompressor_decompressed[7]},_zz_IBusSimplePlugin_decompressor_decompressed[2]},_zz_IBusSimplePlugin_decompressor_decompressed[11]},_zz_IBusSimplePlugin_decompressor_decompressed[5 : 3]},1'b0};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_9 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
   always @(*) begin
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[14] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[13] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[12] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[11] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[10] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[9] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[8] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[7] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[6] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[5] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[4] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[3] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[2] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[1] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
-    _zz_IBusCachedPlugin_decompressor_decompressed_10[0] = _zz_IBusCachedPlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[14] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[13] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[12] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[11] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[10] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[9] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[8] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[7] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[6] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[5] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[4] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[3] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[2] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[1] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
+    _zz_IBusSimplePlugin_decompressor_decompressed_10[0] = _zz_IBusSimplePlugin_decompressor_decompressed_9;
   end
 
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_11 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_11 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
   always @(*) begin
-    _zz_IBusCachedPlugin_decompressor_decompressed_12[2] = _zz_IBusCachedPlugin_decompressor_decompressed_11;
-    _zz_IBusCachedPlugin_decompressor_decompressed_12[1] = _zz_IBusCachedPlugin_decompressor_decompressed_11;
-    _zz_IBusCachedPlugin_decompressor_decompressed_12[0] = _zz_IBusCachedPlugin_decompressor_decompressed_11;
+    _zz_IBusSimplePlugin_decompressor_decompressed_12[2] = _zz_IBusSimplePlugin_decompressor_decompressed_11;
+    _zz_IBusSimplePlugin_decompressor_decompressed_12[1] = _zz_IBusSimplePlugin_decompressor_decompressed_11;
+    _zz_IBusSimplePlugin_decompressor_decompressed_12[0] = _zz_IBusSimplePlugin_decompressor_decompressed_11;
   end
 
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_13 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_13 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
   always @(*) begin
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[9] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[8] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[7] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[6] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[5] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[4] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[3] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[2] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[1] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
-    _zz_IBusCachedPlugin_decompressor_decompressed_14[0] = _zz_IBusCachedPlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[9] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[8] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[7] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[6] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[5] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[4] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[3] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[2] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[1] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
+    _zz_IBusSimplePlugin_decompressor_decompressed_14[0] = _zz_IBusSimplePlugin_decompressor_decompressed_13;
   end
 
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_15 = {{{{{{{{_zz_IBusCachedPlugin_decompressor_decompressed_14,_zz_IBusCachedPlugin_decompressor_decompressed[8]},_zz_IBusCachedPlugin_decompressor_decompressed[10 : 9]},_zz_IBusCachedPlugin_decompressor_decompressed[6]},_zz_IBusCachedPlugin_decompressor_decompressed[7]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11]},_zz_IBusCachedPlugin_decompressor_decompressed[5 : 3]},1'b0};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_16 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_15 = {{{{{{{{_zz_IBusSimplePlugin_decompressor_decompressed_14,_zz_IBusSimplePlugin_decompressor_decompressed[8]},_zz_IBusSimplePlugin_decompressor_decompressed[10 : 9]},_zz_IBusSimplePlugin_decompressor_decompressed[6]},_zz_IBusSimplePlugin_decompressor_decompressed[7]},_zz_IBusSimplePlugin_decompressor_decompressed[2]},_zz_IBusSimplePlugin_decompressor_decompressed[11]},_zz_IBusSimplePlugin_decompressor_decompressed[5 : 3]},1'b0};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_16 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
   always @(*) begin
-    _zz_IBusCachedPlugin_decompressor_decompressed_17[4] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
-    _zz_IBusCachedPlugin_decompressor_decompressed_17[3] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
-    _zz_IBusCachedPlugin_decompressor_decompressed_17[2] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
-    _zz_IBusCachedPlugin_decompressor_decompressed_17[1] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
-    _zz_IBusCachedPlugin_decompressor_decompressed_17[0] = _zz_IBusCachedPlugin_decompressor_decompressed_16;
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[4] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[3] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[2] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[1] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
+    _zz_IBusSimplePlugin_decompressor_decompressed_17[0] = _zz_IBusSimplePlugin_decompressor_decompressed_16;
   end
 
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_18 = {{{{{_zz_IBusCachedPlugin_decompressor_decompressed_17,_zz_IBusCachedPlugin_decompressor_decompressed[6 : 5]},_zz_IBusCachedPlugin_decompressor_decompressed[2]},_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10]},_zz_IBusCachedPlugin_decompressor_decompressed[4 : 3]},1'b0};
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_19 = 5'h0;
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_20 = 5'h01;
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_21 = 5'h02;
-  assign switch_Misc_l44 = {_zz_IBusCachedPlugin_decompressor_decompressed[1 : 0],_zz_IBusCachedPlugin_decompressor_decompressed[15 : 13]};
-  assign when_Misc_l47 = (_zz_IBusCachedPlugin_decompressor_decompressed[12 : 2] == 11'h0);
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_22 = (_zz_IBusCachedPlugin_decompressor_decompressed[11 : 10] != 2'b11);
-  assign switch_Misc_l241 = _zz_IBusCachedPlugin_decompressor_decompressed[11 : 10];
-  assign switch_Misc_l241_1 = _zz_IBusCachedPlugin_decompressor_decompressed[6 : 5];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_18 = {{{{{_zz_IBusSimplePlugin_decompressor_decompressed_17,_zz_IBusSimplePlugin_decompressor_decompressed[6 : 5]},_zz_IBusSimplePlugin_decompressor_decompressed[2]},_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10]},_zz_IBusSimplePlugin_decompressor_decompressed[4 : 3]},1'b0};
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_19 = 5'h0;
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_20 = 5'h01;
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_21 = 5'h02;
+  assign switch_Misc_l44 = {_zz_IBusSimplePlugin_decompressor_decompressed[1 : 0],_zz_IBusSimplePlugin_decompressor_decompressed[15 : 13]};
+  assign when_Misc_l47 = (_zz_IBusSimplePlugin_decompressor_decompressed[12 : 2] == 11'h0);
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_22 = (_zz_IBusSimplePlugin_decompressor_decompressed[11 : 10] != 2'b11);
+  assign switch_Misc_l241 = _zz_IBusSimplePlugin_decompressor_decompressed[11 : 10];
+  assign switch_Misc_l241_1 = _zz_IBusSimplePlugin_decompressor_decompressed[6 : 5];
   always @(*) begin
     case(switch_Misc_l241_1)
       2'b00 : begin
-        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b000;
+        _zz_IBusSimplePlugin_decompressor_decompressed_23 = 3'b000;
       end
       2'b01 : begin
-        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b100;
+        _zz_IBusSimplePlugin_decompressor_decompressed_23 = 3'b100;
       end
       2'b10 : begin
-        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b110;
+        _zz_IBusSimplePlugin_decompressor_decompressed_23 = 3'b110;
       end
       default : begin
-        _zz_IBusCachedPlugin_decompressor_decompressed_23 = 3'b111;
+        _zz_IBusSimplePlugin_decompressor_decompressed_23 = 3'b111;
       end
     endcase
   end
@@ -3476,194 +3375,174 @@ module VexRiscv (
   always @(*) begin
     case(switch_Misc_l241)
       2'b00 : begin
-        _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b101;
+        _zz_IBusSimplePlugin_decompressor_decompressed_24 = 3'b101;
       end
       2'b01 : begin
-        _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b101;
+        _zz_IBusSimplePlugin_decompressor_decompressed_24 = 3'b101;
       end
       2'b10 : begin
-        _zz_IBusCachedPlugin_decompressor_decompressed_24 = 3'b111;
+        _zz_IBusSimplePlugin_decompressor_decompressed_24 = 3'b111;
       end
       default : begin
-        _zz_IBusCachedPlugin_decompressor_decompressed_24 = _zz_IBusCachedPlugin_decompressor_decompressed_23;
+        _zz_IBusSimplePlugin_decompressor_decompressed_24 = _zz_IBusSimplePlugin_decompressor_decompressed_23;
       end
     endcase
   end
 
-  assign _zz_IBusCachedPlugin_decompressor_decompressed_25 = _zz_IBusCachedPlugin_decompressor_decompressed[12];
+  assign _zz_IBusSimplePlugin_decompressor_decompressed_25 = _zz_IBusSimplePlugin_decompressor_decompressed[12];
   always @(*) begin
-    _zz_IBusCachedPlugin_decompressor_decompressed_26[6] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
-    _zz_IBusCachedPlugin_decompressor_decompressed_26[5] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
-    _zz_IBusCachedPlugin_decompressor_decompressed_26[4] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
-    _zz_IBusCachedPlugin_decompressor_decompressed_26[3] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
-    _zz_IBusCachedPlugin_decompressor_decompressed_26[2] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
-    _zz_IBusCachedPlugin_decompressor_decompressed_26[1] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
-    _zz_IBusCachedPlugin_decompressor_decompressed_26[0] = _zz_IBusCachedPlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[6] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[5] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[4] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[3] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[2] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[1] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
+    _zz_IBusSimplePlugin_decompressor_decompressed_26[0] = _zz_IBusSimplePlugin_decompressor_decompressed_25;
   end
 
-  assign IBusCachedPlugin_decompressor_output_valid = (IBusCachedPlugin_decompressor_input_valid && (! ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_bufferValid)) && (! IBusCachedPlugin_decompressor_isInputHighRvc))));
-  assign IBusCachedPlugin_decompressor_output_payload_pc = IBusCachedPlugin_decompressor_input_payload_pc;
-  assign IBusCachedPlugin_decompressor_output_payload_isRvc = IBusCachedPlugin_decompressor_isRvc;
-  assign IBusCachedPlugin_decompressor_output_payload_rsp_inst = (IBusCachedPlugin_decompressor_isRvc ? IBusCachedPlugin_decompressor_decompressed : IBusCachedPlugin_decompressor_raw);
-  assign IBusCachedPlugin_decompressor_input_ready = (IBusCachedPlugin_decompressor_output_ready && (((! IBusCachedPlugin_iBusRsp_stages_1_input_valid) || IBusCachedPlugin_decompressor_flushNext) || ((! (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc)) && (! (((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc)))));
-  assign IBusCachedPlugin_decompressor_output_fire = (IBusCachedPlugin_decompressor_output_valid && IBusCachedPlugin_decompressor_output_ready);
-  assign IBusCachedPlugin_decompressor_bufferFill = (((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && (! IBusCachedPlugin_decompressor_isInputHighRvc)) || (IBusCachedPlugin_decompressor_bufferValid && (! IBusCachedPlugin_decompressor_isInputHighRvc))) || ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_isRvc)) && (! IBusCachedPlugin_decompressor_isInputHighRvc)));
-  assign when_Fetcher_l285 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign when_Fetcher_l288 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign when_Fetcher_l293 = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_decompressor_consumeCurrent);
-  assign IBusCachedPlugin_decompressor_output_ready = ((1'b0 && (! IBusCachedPlugin_injector_decodeInput_valid)) || IBusCachedPlugin_injector_decodeInput_ready);
-  assign IBusCachedPlugin_injector_decodeInput_valid = _zz_IBusCachedPlugin_injector_decodeInput_valid;
-  assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_IBusCachedPlugin_injector_decodeInput_payload_pc;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
-  assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc;
+  assign IBusSimplePlugin_decompressor_output_valid = (IBusSimplePlugin_decompressor_input_valid && (! ((IBusSimplePlugin_decompressor_throw2Bytes && (! IBusSimplePlugin_decompressor_bufferValid)) && (! IBusSimplePlugin_decompressor_isInputHighRvc))));
+  assign IBusSimplePlugin_decompressor_output_payload_pc = IBusSimplePlugin_decompressor_input_payload_pc;
+  assign IBusSimplePlugin_decompressor_output_payload_isRvc = IBusSimplePlugin_decompressor_isRvc;
+  assign IBusSimplePlugin_decompressor_output_payload_rsp_inst = (IBusSimplePlugin_decompressor_isRvc ? IBusSimplePlugin_decompressor_decompressed : IBusSimplePlugin_decompressor_raw);
+  assign IBusSimplePlugin_decompressor_input_ready = (IBusSimplePlugin_decompressor_output_ready && (((! IBusSimplePlugin_iBusRsp_stages_1_input_valid) || IBusSimplePlugin_decompressor_flushNext) || ((! (IBusSimplePlugin_decompressor_bufferValid && IBusSimplePlugin_decompressor_isInputHighRvc)) && (! (((! IBusSimplePlugin_decompressor_unaligned) && IBusSimplePlugin_decompressor_isInputLowRvc) && IBusSimplePlugin_decompressor_isInputHighRvc)))));
+  assign IBusSimplePlugin_decompressor_output_fire = (IBusSimplePlugin_decompressor_output_valid && IBusSimplePlugin_decompressor_output_ready);
+  assign IBusSimplePlugin_decompressor_bufferFill = (((((! IBusSimplePlugin_decompressor_unaligned) && IBusSimplePlugin_decompressor_isInputLowRvc) && (! IBusSimplePlugin_decompressor_isInputHighRvc)) || (IBusSimplePlugin_decompressor_bufferValid && (! IBusSimplePlugin_decompressor_isInputHighRvc))) || ((IBusSimplePlugin_decompressor_throw2Bytes && (! IBusSimplePlugin_decompressor_isRvc)) && (! IBusSimplePlugin_decompressor_isInputHighRvc)));
+  assign when_Fetcher_l285 = (IBusSimplePlugin_decompressor_output_ready && IBusSimplePlugin_decompressor_input_valid);
+  assign when_Fetcher_l288 = (IBusSimplePlugin_decompressor_output_ready && IBusSimplePlugin_decompressor_input_valid);
+  assign when_Fetcher_l293 = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_decompressor_consumeCurrent);
+  assign IBusSimplePlugin_decompressor_output_ready = ((1'b0 && (! IBusSimplePlugin_injector_decodeInput_valid)) || IBusSimplePlugin_injector_decodeInput_ready);
+  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_IBusSimplePlugin_injector_decodeInput_valid;
+  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_IBusSimplePlugin_injector_decodeInput_payload_pc;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
+  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc;
   assign when_Fetcher_l331 = (! 1'b0);
   assign when_Fetcher_l331_1 = (! execute_arbitration_isStuck);
   assign when_Fetcher_l331_2 = (! memory_arbitration_isStuck);
   assign when_Fetcher_l331_3 = (! writeBack_arbitration_isStuck);
-  assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_0;
-  assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
-  assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
-  assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
-  assign IBusCachedPlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
+  assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_0;
+  assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
+  assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
+  assign IBusSimplePlugin_pcValids_3 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
+  assign IBusSimplePlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
   always @(*) begin
-    decode_arbitration_isValid = IBusCachedPlugin_injector_decodeInput_valid;
-    if(IBusCachedPlugin_forceNoDecodeCond) begin
+    decode_arbitration_isValid = IBusSimplePlugin_injector_decodeInput_valid;
+    if(IBusSimplePlugin_forceNoDecodeCond) begin
       decode_arbitration_isValid = 1'b0;
     end
   end
 
-  assign _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch[11];
+  assign _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch = _zz__zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch[11];
   always @(*) begin
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-    _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[18] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[17] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[16] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[15] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[14] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[13] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[12] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[11] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[10] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[9] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[8] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[7] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[6] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[5] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[4] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[3] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[2] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[1] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
+    _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_1[0] = _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch;
   end
 
-  assign IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusCachedPlugin_decodePrediction_cmd_hadBranch_2[31]));
-  assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload[19];
+  assign IBusSimplePlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) || ((decode_BRANCH_CTRL == BranchCtrlEnum_B) && _zz_IBusSimplePlugin_decodePrediction_cmd_hadBranch_2[31]));
+  assign IBusSimplePlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusSimplePlugin_decodePrediction_cmd_hadBranch);
+  assign _zz_IBusSimplePlugin_predictionJumpInterface_payload = _zz__zz_IBusSimplePlugin_predictionJumpInterface_payload[19];
   always @(*) begin
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_1[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[10] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[9] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[8] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[7] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[6] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[5] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[4] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[3] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[2] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[1] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_1[0] = _zz_IBusSimplePlugin_predictionJumpInterface_payload;
   end
 
-  assign _zz_IBusCachedPlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusCachedPlugin_predictionJumpInterface_payload_2[11];
+  assign _zz_IBusSimplePlugin_predictionJumpInterface_payload_2 = _zz__zz_IBusSimplePlugin_predictionJumpInterface_payload_2[11];
   always @(*) begin
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[18] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[17] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[16] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[15] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[14] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[13] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[12] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[11] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[10] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[9] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[8] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[7] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[6] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[5] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[4] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[3] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[2] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[1] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
-    _zz_IBusCachedPlugin_predictionJumpInterface_payload_3[0] = _zz_IBusCachedPlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[18] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[17] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[16] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[15] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[14] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[13] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[12] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[11] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[10] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[9] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[8] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[7] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[6] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[5] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[4] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[3] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[2] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[1] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
+    _zz_IBusSimplePlugin_predictionJumpInterface_payload_3[0] = _zz_IBusSimplePlugin_predictionJumpInterface_payload_2;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_1,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_4,_zz_IBusCachedPlugin_predictionJumpInterface_payload_5},_zz_IBusCachedPlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusCachedPlugin_predictionJumpInterface_payload_3,{{{_zz_IBusCachedPlugin_predictionJumpInterface_payload_7,_zz_IBusCachedPlugin_predictionJumpInterface_payload_8},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
-  assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
+  assign IBusSimplePlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == BranchCtrlEnum_JAL) ? {{_zz_IBusSimplePlugin_predictionJumpInterface_payload_1,{{{_zz_IBusSimplePlugin_predictionJumpInterface_payload_4,_zz_IBusSimplePlugin_predictionJumpInterface_payload_5},_zz_IBusSimplePlugin_predictionJumpInterface_payload_6},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_IBusSimplePlugin_predictionJumpInterface_payload_3,{{{_zz_IBusSimplePlugin_predictionJumpInterface_payload_7,_zz_IBusSimplePlugin_predictionJumpInterface_payload_8},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign iBus_cmd_valid = IBusSimplePlugin_cmd_valid;
+  assign IBusSimplePlugin_cmd_ready = iBus_cmd_ready;
+  assign iBus_cmd_payload_pc = IBusSimplePlugin_cmd_payload_pc;
+  assign IBusSimplePlugin_pending_next = (_zz_IBusSimplePlugin_pending_next - _zz_IBusSimplePlugin_pending_next_3);
+  assign IBusSimplePlugin_cmdFork_canEmit = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && (IBusSimplePlugin_pending_value != 3'b111));
+  assign when_IBusSimplePlugin_l305 = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready)));
+  assign IBusSimplePlugin_cmd_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && IBusSimplePlugin_cmdFork_canEmit);
+  assign IBusSimplePlugin_cmd_fire = (IBusSimplePlugin_cmd_valid && IBusSimplePlugin_cmd_ready);
+  assign IBusSimplePlugin_pending_inc = IBusSimplePlugin_cmd_fire;
+  assign IBusSimplePlugin_cmd_payload_pc = {IBusSimplePlugin_iBusRsp_stages_0_input_payload[31 : 2],2'b00};
+  assign iBus_rsp_toStream_valid = iBus_rsp_valid;
+  assign iBus_rsp_toStream_payload_error = iBus_rsp_payload_error;
+  assign iBus_rsp_toStream_payload_inst = iBus_rsp_payload_inst;
+  assign iBus_rsp_toStream_ready = IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_flush = ((IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000) || IBusSimplePlugin_iBusRsp_flush);
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_valid = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter == 3'b000));
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
+  assign IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
+  assign toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_ready);
+  assign IBusSimplePlugin_pending_dec = toplevel_IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_fire;
+  assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   always @(*) begin
-    iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
-    iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
-  end
-
-  assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign IBusCachedPlugin_cache_io_cpu_prefetch_isValid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign IBusCachedPlugin_cache_io_cpu_fetch_isValid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign IBusCachedPlugin_cache_io_cpu_fetch_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = IBusCachedPlugin_cache_io_cpu_fetch_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
-  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign IBusCachedPlugin_cache_io_cpu_fetch_isUser = (CsrPlugin_privilege == 2'b00);
-  assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
-  assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
-  always @(*) begin
-    IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(when_IBusCachedPlugin_l245) begin
-      IBusCachedPlugin_rsp_redoFetch = 1'b1;
-    end
-    if(when_IBusCachedPlugin_l256) begin
-      IBusCachedPlugin_rsp_redoFetch = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    IBusCachedPlugin_cache_io_cpu_fill_valid = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
-    if(when_IBusCachedPlugin_l256) begin
-      IBusCachedPlugin_cache_io_cpu_fill_valid = 1'b1;
+    IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
+    if(when_IBusSimplePlugin_l376) begin
+      IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = 1'b0;
     end
   end
 
-  always @(*) begin
-    IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(when_IBusCachedPlugin_l250) begin
-      IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
-    end
-    if(when_IBusCachedPlugin_l262) begin
-      IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
-    end
-  end
-
-  always @(*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(when_IBusCachedPlugin_l250) begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
-    end
-    if(when_IBusCachedPlugin_l262) begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
-    end
-  end
-
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_1_input_payload[31 : 2],2'b00};
-  assign when_IBusCachedPlugin_l245 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign when_IBusCachedPlugin_l250 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign when_IBusCachedPlugin_l256 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign when_IBusCachedPlugin_l262 = ((IBusCachedPlugin_cache_io_cpu_fetch_isValid && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign when_IBusCachedPlugin_l273 = (IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt);
-  assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_1_output_valid;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
-  assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_fetch_data;
-  assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_1_output_payload;
-  assign IBusCachedPlugin_cache_io_flush = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
+  assign when_IBusSimplePlugin_l376 = (! IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
+  assign IBusSimplePlugin_rspJoin_exceptionDetected = 1'b0;
+  assign IBusSimplePlugin_rspJoin_join_valid = (IBusSimplePlugin_iBusRsp_stages_1_output_valid && IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
+  assign IBusSimplePlugin_rspJoin_join_payload_pc = IBusSimplePlugin_rspJoin_fetchRsp_pc;
+  assign IBusSimplePlugin_rspJoin_join_payload_rsp_error = IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
+  assign IBusSimplePlugin_rspJoin_join_payload_rsp_inst = IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst;
+  assign IBusSimplePlugin_rspJoin_join_payload_isRvc = IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
+  assign IBusSimplePlugin_rspJoin_join_fire = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_valid ? IBusSimplePlugin_rspJoin_join_fire : IBusSimplePlugin_rspJoin_join_ready);
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = IBusSimplePlugin_rspJoin_join_fire;
+  assign _zz_IBusSimplePlugin_iBusRsp_output_valid = (! IBusSimplePlugin_rspJoin_exceptionDetected);
+  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_IBusSimplePlugin_iBusRsp_output_valid);
+  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_IBusSimplePlugin_iBusRsp_output_valid);
+  assign IBusSimplePlugin_iBusRsp_output_payload_pc = IBusSimplePlugin_rspJoin_join_payload_pc;
+  assign IBusSimplePlugin_iBusRsp_output_payload_rsp_error = IBusSimplePlugin_rspJoin_join_payload_rsp_error;
+  assign IBusSimplePlugin_iBusRsp_output_payload_rsp_inst = IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
+  assign IBusSimplePlugin_iBusRsp_output_payload_isRvc = IBusSimplePlugin_rspJoin_join_payload_isRvc;
   assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || (! toplevel_dataCache_1_io_mem_cmd_rValidN));
   assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_wr : toplevel_dataCache_1_io_mem_cmd_rData_wr);
   assign toplevel_dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (toplevel_dataCache_1_io_mem_cmd_rValidN ? dataCache_1_io_mem_cmd_payload_uncached : toplevel_dataCache_1_io_mem_cmd_rData_uncached);
@@ -3730,7 +3609,7 @@ module VexRiscv (
 
   assign dataCache_1_io_cpu_flush_valid = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
   assign dataCache_1_io_cpu_flush_payload_singleLine = (execute_INSTRUCTION[19 : 15] != 5'h0);
-  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[6:0];
+  assign dataCache_1_io_cpu_flush_payload_lineId = _zz_io_cpu_flush_payload_lineId[4:0];
   assign toplevel_dataCache_1_io_cpu_flush_isStall = (dataCache_1_io_cpu_flush_valid && (! dataCache_1_io_cpu_flush_ready));
   assign when_DBusCachedPlugin_l395 = (toplevel_dataCache_1_io_cpu_flush_isStall || dataCache_1_io_cpu_execute_haltIt);
   always @(*) begin
@@ -3900,15 +3779,6 @@ module VexRiscv (
   end
 
   assign when_DBusCachedPlugin_l581 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
-  assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
-  assign IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
-  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
-  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-  assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-  assign IBusCachedPlugin_mmuBus_busy = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
@@ -3927,19 +3797,19 @@ module VexRiscv (
   assign _zz_decode_IS_RS2_SIGNED_7 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
   assign _zz_decode_IS_RS2_SIGNED_8 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
   assign _zz_decode_IS_RS2_SIGNED = {(|_zz_decode_IS_RS2_SIGNED_8),{(|_zz_decode_IS_RS2_SIGNED_8),{(|(_zz__zz_decode_IS_RS2_SIGNED == _zz__zz_decode_IS_RS2_SIGNED_1)),{(|_zz__zz_decode_IS_RS2_SIGNED_2),{(|_zz__zz_decode_IS_RS2_SIGNED_3),{_zz__zz_decode_IS_RS2_SIGNED_4,{_zz__zz_decode_IS_RS2_SIGNED_9,_zz__zz_decode_IS_RS2_SIGNED_12}}}}}}};
-  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[2 : 1];
+  assign _zz_decode_SRC1_CTRL_2 = _zz_decode_IS_RS2_SIGNED[1 : 0];
   assign _zz_decode_SRC1_CTRL_1 = _zz_decode_SRC1_CTRL_2;
-  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[7 : 6];
+  assign _zz_decode_ALU_CTRL_2 = _zz_decode_IS_RS2_SIGNED[6 : 5];
   assign _zz_decode_ALU_CTRL_1 = _zz_decode_ALU_CTRL_2;
-  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[9 : 8];
+  assign _zz_decode_SRC2_CTRL_2 = _zz_decode_IS_RS2_SIGNED[8 : 7];
   assign _zz_decode_SRC2_CTRL_1 = _zz_decode_SRC2_CTRL_2;
-  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[22 : 21];
+  assign _zz_decode_ALU_BITWISE_CTRL_2 = _zz_decode_IS_RS2_SIGNED[21 : 20];
   assign _zz_decode_ALU_BITWISE_CTRL_1 = _zz_decode_ALU_BITWISE_CTRL_2;
-  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[24 : 23];
+  assign _zz_decode_SHIFT_CTRL_2 = _zz_decode_IS_RS2_SIGNED[23 : 22];
   assign _zz_decode_SHIFT_CTRL_1 = _zz_decode_SHIFT_CTRL_2;
-  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[26 : 25];
+  assign _zz_decode_BRANCH_CTRL_2 = _zz_decode_IS_RS2_SIGNED[25 : 24];
   assign _zz_decode_BRANCH_CTRL = _zz_decode_BRANCH_CTRL_2;
-  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[30 : 28];
+  assign _zz_decode_ENV_CTRL_2 = _zz_decode_IS_RS2_SIGNED[29 : 27];
   assign _zz_decode_ENV_CTRL_1 = _zz_decode_ENV_CTRL_2;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
@@ -4370,7 +4240,7 @@ module VexRiscv (
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
-  assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
+  assign IBusSimplePlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @(*) begin
     CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire) begin
@@ -4385,11 +4255,9 @@ module VexRiscv (
   assign _zz_when_CsrPlugin_l1302_2 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 = _zz__zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1[0];
   always @(*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_when) begin
+    if(decodeExceptionPort_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed) begin
@@ -4928,7 +4796,7 @@ module VexRiscv (
   always @(*) begin
     _zz_CsrPlugin_csrMapping_readDataInit_1 = 32'h0;
     if(execute_CsrPlugin_csr_3264) begin
-      _zz_CsrPlugin_csrMapping_readDataInit_1[12 : 0] = 13'h1000;
+      _zz_CsrPlugin_csrMapping_readDataInit_1[10 : 0] = 11'h400;
       _zz_CsrPlugin_csrMapping_readDataInit_1[25 : 20] = 6'h20;
     end
   end
@@ -5109,32 +4977,28 @@ module VexRiscv (
 
   assign when_CsrPlugin_l1717 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
   assign when_CsrPlugin_l1725 = ((! execute_arbitration_isValid) || (! execute_IS_CSR));
-  assign iBusWishbone_ADR = {_zz_iBusWishbone_ADR_1,_zz_iBusWishbone_ADR};
-  assign iBusWishbone_CTI = ((_zz_iBusWishbone_ADR == 3'b111) ? 3'b111 : 3'b010);
+  always @(*) begin
+    iBus_cmd_ready = iBus_cmd_m2sPipe_ready;
+    if(when_Stream_l375_1) begin
+      iBus_cmd_ready = 1'b1;
+    end
+  end
+
+  assign when_Stream_l375_1 = (! iBus_cmd_m2sPipe_valid);
+  assign iBus_cmd_m2sPipe_valid = iBus_cmd_rValid;
+  assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_rData_pc;
+  assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2'd2);
+  assign iBusWishbone_CTI = 3'b000;
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'bxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx;
-  always @(*) begin
-    iBusWishbone_CYC = 1'b0;
-    if(when_InstructionCache_l239) begin
-      iBusWishbone_CYC = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    iBusWishbone_STB = 1'b0;
-    if(when_InstructionCache_l239) begin
-      iBusWishbone_STB = 1'b1;
-    end
-  end
-
-  assign when_InstructionCache_l239 = (iBus_cmd_valid || (_zz_iBusWishbone_ADR != 3'b000));
-  assign when_InstructionCache_l242 = (iBusWishbone_ACK || iBusWishbone_ERR);
-  assign iBus_cmd_ready = (iBus_cmd_valid && (iBusWishbone_ACK || iBusWishbone_ERR));
-  assign iBus_rsp_valid = _zz_iBus_rsp_valid;
-  assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
-  assign iBus_rsp_payload_error = iBusWishbone_ERR_regNext;
+  assign iBusWishbone_CYC = iBus_cmd_m2sPipe_valid;
+  assign iBusWishbone_STB = iBus_cmd_m2sPipe_valid;
+  assign iBus_cmd_m2sPipe_ready = (iBus_cmd_m2sPipe_valid && (iBusWishbone_ACK || iBusWishbone_ERR));
+  assign iBus_rsp_valid = (iBusWishbone_CYC && (iBusWishbone_ACK || iBusWishbone_ERR));
+  assign iBus_rsp_payload_inst = iBusWishbone_DAT_MISO;
+  assign iBus_rsp_payload_error = iBusWishbone_ERR;
   assign _zz_dBusWishbone_ADR_1 = (dBus_cmd_payload_size == 3'b101);
   assign _zz_dBusWishbone_CYC = dBus_cmd_valid;
   assign _zz_dBus_cmd_ready_1 = dBus_cmd_payload_wr;
@@ -5154,20 +5018,21 @@ module VexRiscv (
   assign dBus_rsp_payload_error = dBusWishbone_ERR_regNext;
   always @(posedge clk) begin
     if(reset) begin
-      IBusCachedPlugin_fetchPc_pcReg <= externalResetVector;
-      IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
-      IBusCachedPlugin_fetchPc_booted <= 1'b0;
-      IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      IBusCachedPlugin_decodePc_pcReg <= externalResetVector;
-      _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
-      IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
-      IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
-      _zz_IBusCachedPlugin_injector_decodeInput_valid <= 1'b0;
-      IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
-      IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
-      IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
-      IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= 32'h0;
+      IBusSimplePlugin_fetchPc_pcReg <= externalResetVector;
+      IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
+      IBusSimplePlugin_fetchPc_booted <= 1'b0;
+      IBusSimplePlugin_fetchPc_inc <= 1'b0;
+      IBusSimplePlugin_decodePc_pcReg <= externalResetVector;
+      _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
+      IBusSimplePlugin_decompressor_bufferValid <= 1'b0;
+      IBusSimplePlugin_decompressor_throw2BytesReg <= 1'b0;
+      _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
+      IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
+      IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
+      IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
+      IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      IBusSimplePlugin_pending_value <= 3'b000;
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= 3'b000;
       toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b1;
       toplevel_dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       DBusCachedPlugin_rspCounter <= 32'h0;
@@ -5197,89 +5062,90 @@ module VexRiscv (
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_iBusWishbone_ADR <= 3'b000;
-      _zz_iBus_rsp_valid <= 1'b0;
+      iBus_cmd_rValid <= 1'b0;
       _zz_dBusWishbone_ADR <= 3'b000;
       _zz_dBus_rsp_valid <= 1'b0;
     end else begin
-      if(IBusCachedPlugin_fetchPc_correction) begin
-        IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
+      if(IBusSimplePlugin_fetchPc_correction) begin
+        IBusSimplePlugin_fetchPc_correctionReg <= 1'b1;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire) begin
-        IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
+      if(IBusSimplePlugin_fetchPc_output_fire) begin
+        IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       end
-      IBusCachedPlugin_fetchPc_booted <= 1'b1;
+      IBusSimplePlugin_fetchPc_booted <= 1'b1;
       if(when_Fetcher_l133) begin
-        IBusCachedPlugin_fetchPc_inc <= 1'b0;
+        IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
-      if(IBusCachedPlugin_fetchPc_output_fire) begin
-        IBusCachedPlugin_fetchPc_inc <= 1'b1;
+      if(IBusSimplePlugin_fetchPc_output_fire) begin
+        IBusSimplePlugin_fetchPc_inc <= 1'b1;
       end
       if(when_Fetcher_l133_1) begin
-        IBusCachedPlugin_fetchPc_inc <= 1'b0;
+        IBusSimplePlugin_fetchPc_inc <= 1'b0;
       end
       if(when_Fetcher_l160) begin
-        IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
+        IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
       end
       if(when_Fetcher_l182) begin
-        IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_decodePc_pcPlus;
+        IBusSimplePlugin_decodePc_pcReg <= IBusSimplePlugin_decodePc_pcPlus;
       end
       if(when_Fetcher_l194) begin
-        IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_jump_pcLoad_payload;
+        IBusSimplePlugin_decodePc_pcReg <= IBusSimplePlugin_jump_pcLoad_payload;
       end
-      if(IBusCachedPlugin_iBusRsp_flush) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
+      if(IBusSimplePlugin_iBusRsp_flush) begin
+        _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= 1'b0;
       end
-      if(_zz_IBusCachedPlugin_iBusRsp_stages_0_output_ready) begin
-        _zz_IBusCachedPlugin_iBusRsp_stages_1_input_valid_1 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_IBusSimplePlugin_iBusRsp_stages_0_output_ready) begin
+        _zz_IBusSimplePlugin_iBusRsp_stages_1_input_valid_1 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
-      if(IBusCachedPlugin_decompressor_output_fire) begin
-        IBusCachedPlugin_decompressor_throw2BytesReg <= ((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc) || (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc));
+      if(IBusSimplePlugin_decompressor_output_fire) begin
+        IBusSimplePlugin_decompressor_throw2BytesReg <= ((((! IBusSimplePlugin_decompressor_unaligned) && IBusSimplePlugin_decompressor_isInputLowRvc) && IBusSimplePlugin_decompressor_isInputHighRvc) || (IBusSimplePlugin_decompressor_bufferValid && IBusSimplePlugin_decompressor_isInputHighRvc));
       end
       if(when_Fetcher_l285) begin
-        IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
+        IBusSimplePlugin_decompressor_bufferValid <= 1'b0;
       end
       if(when_Fetcher_l288) begin
-        if(IBusCachedPlugin_decompressor_bufferFill) begin
-          IBusCachedPlugin_decompressor_bufferValid <= 1'b1;
+        if(IBusSimplePlugin_decompressor_bufferFill) begin
+          IBusSimplePlugin_decompressor_bufferValid <= 1'b1;
         end
       end
       if(when_Fetcher_l293) begin
-        IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
-        IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
+        IBusSimplePlugin_decompressor_throw2BytesReg <= 1'b0;
+        IBusSimplePlugin_decompressor_bufferValid <= 1'b0;
       end
       if(decode_arbitration_removeIt) begin
-        _zz_IBusCachedPlugin_injector_decodeInput_valid <= 1'b0;
+        _zz_IBusSimplePlugin_injector_decodeInput_valid <= 1'b0;
       end
-      if(IBusCachedPlugin_decompressor_output_ready) begin
-        _zz_IBusCachedPlugin_injector_decodeInput_valid <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
+      if(IBusSimplePlugin_decompressor_output_ready) begin
+        _zz_IBusSimplePlugin_injector_decodeInput_valid <= (IBusSimplePlugin_decompressor_output_valid && (! IBusSimplePlugin_externalFlush));
       end
       if(when_Fetcher_l331) begin
-        IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
+        IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b1;
       end
-      if(IBusCachedPlugin_decodePc_flushed) begin
-        IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
+      if(IBusSimplePlugin_decodePc_flushed) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       end
       if(when_Fetcher_l331_1) begin
-        IBusCachedPlugin_injector_nextPcCalc_valids_1 <= IBusCachedPlugin_injector_nextPcCalc_valids_0;
+        IBusSimplePlugin_injector_nextPcCalc_valids_1 <= IBusSimplePlugin_injector_nextPcCalc_valids_0;
       end
-      if(IBusCachedPlugin_decodePc_flushed) begin
-        IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
+      if(IBusSimplePlugin_decodePc_flushed) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       end
       if(when_Fetcher_l331_2) begin
-        IBusCachedPlugin_injector_nextPcCalc_valids_2 <= IBusCachedPlugin_injector_nextPcCalc_valids_1;
+        IBusSimplePlugin_injector_nextPcCalc_valids_2 <= IBusSimplePlugin_injector_nextPcCalc_valids_1;
       end
-      if(IBusCachedPlugin_decodePc_flushed) begin
-        IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
+      if(IBusSimplePlugin_decodePc_flushed) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       end
       if(when_Fetcher_l331_3) begin
-        IBusCachedPlugin_injector_nextPcCalc_valids_3 <= IBusCachedPlugin_injector_nextPcCalc_valids_2;
+        IBusSimplePlugin_injector_nextPcCalc_valids_3 <= IBusSimplePlugin_injector_nextPcCalc_valids_2;
       end
-      if(IBusCachedPlugin_decodePc_flushed) begin
-        IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
+      if(IBusSimplePlugin_decodePc_flushed) begin
+        IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       end
-      if(iBus_rsp_valid) begin
-        IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
+      IBusSimplePlugin_pending_value <= IBusSimplePlugin_pending_next;
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter);
+      if(IBusSimplePlugin_iBusRsp_flush) begin
+        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_IBusSimplePlugin_rspJoin_rspBuffer_discardCounter_2);
       end
       if(dataCache_1_io_mem_cmd_valid) begin
         toplevel_dataCache_1_io_mem_cmd_rValidN <= 1'b0;
@@ -5441,12 +5307,9 @@ module VexRiscv (
           _zz_CsrPlugin_csrMapping_readDataInit <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
         end
       end
-      if(when_InstructionCache_l239) begin
-        if(when_InstructionCache_l242) begin
-          _zz_iBusWishbone_ADR <= (_zz_iBusWishbone_ADR + 3'b001);
-        end
+      if(iBus_cmd_ready) begin
+        iBus_cmd_rValid <= iBus_cmd_valid;
       end
-      _zz_iBus_rsp_valid <= (iBusWishbone_CYC && (iBusWishbone_ACK || iBusWishbone_ERR));
       if((_zz_dBusWishbone_CYC && _zz_dBus_cmd_ready)) begin
         _zz_dBusWishbone_ADR <= (_zz_dBusWishbone_ADR + 3'b001);
         if(_zz_dBus_cmd_ready_2) begin
@@ -5458,26 +5321,23 @@ module VexRiscv (
   end
 
   always @(posedge clk) begin
-    if(IBusCachedPlugin_decompressor_input_valid) begin
-      IBusCachedPlugin_decompressor_bufferValidLatch <= IBusCachedPlugin_decompressor_bufferValid;
+    if(IBusSimplePlugin_decompressor_input_valid) begin
+      IBusSimplePlugin_decompressor_bufferValidLatch <= IBusSimplePlugin_decompressor_bufferValid;
     end
-    if(IBusCachedPlugin_decompressor_input_valid) begin
-      IBusCachedPlugin_decompressor_throw2BytesLatch <= IBusCachedPlugin_decompressor_throw2Bytes;
+    if(IBusSimplePlugin_decompressor_input_valid) begin
+      IBusSimplePlugin_decompressor_throw2BytesLatch <= IBusSimplePlugin_decompressor_throw2Bytes;
     end
     if(when_Fetcher_l288) begin
-      IBusCachedPlugin_decompressor_bufferData <= IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16];
+      IBusSimplePlugin_decompressor_bufferData <= IBusSimplePlugin_decompressor_input_payload_rsp_inst[31 : 16];
     end
-    if(IBusCachedPlugin_decompressor_output_ready) begin
-      _zz_IBusCachedPlugin_injector_decodeInput_payload_pc <= IBusCachedPlugin_decompressor_output_payload_pc;
-      _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_error <= IBusCachedPlugin_decompressor_output_payload_rsp_error;
-      _zz_IBusCachedPlugin_injector_decodeInput_payload_rsp_inst <= IBusCachedPlugin_decompressor_output_payload_rsp_inst;
-      _zz_IBusCachedPlugin_injector_decodeInput_payload_isRvc <= IBusCachedPlugin_decompressor_output_payload_isRvc;
+    if(IBusSimplePlugin_decompressor_output_ready) begin
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_pc <= IBusSimplePlugin_decompressor_output_payload_pc;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_error <= IBusSimplePlugin_decompressor_output_payload_rsp_error;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_rsp_inst <= IBusSimplePlugin_decompressor_output_payload_rsp_inst;
+      _zz_IBusSimplePlugin_injector_decodeInput_payload_isRvc <= IBusSimplePlugin_decompressor_output_payload_isRvc;
     end
-    if(IBusCachedPlugin_injector_decodeInput_ready) begin
-      IBusCachedPlugin_injector_formal_rawInDecode <= IBusCachedPlugin_decompressor_raw;
-    end
-    if(IBusCachedPlugin_iBusRsp_stages_1_input_ready) begin
-      IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
+    if(IBusSimplePlugin_injector_decodeInput_ready) begin
+      IBusSimplePlugin_injector_formal_rawInDecode <= IBusSimplePlugin_decompressor_raw;
     end
     if(toplevel_dataCache_1_io_mem_cmd_rValidN) begin
       toplevel_dataCache_1_io_mem_cmd_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
@@ -5502,9 +5362,9 @@ module VexRiscv (
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
-    if(_zz_when) begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_CsrPlugin_exceptionPortCtrl_exceptionContext_code_1 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(decodeExceptionPort_valid) begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= decodeExceptionPort_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= decodeExceptionPort_payload_badAddr;
     end
     if(CsrPlugin_selfException_valid) begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -5870,8 +5730,9 @@ module VexRiscv (
         CsrPlugin_mtval <= CsrPlugin_csrMapping_writeDataSignal[31 : 0];
       end
     end
-    iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
-    iBusWishbone_ERR_regNext <= iBusWishbone_ERR;
+    if(iBus_cmd_ready) begin
+      iBus_cmd_rData_pc <= iBus_cmd_payload_pc;
+    end
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
     dBusWishbone_ERR_regNext <= dBusWishbone_ERR;
   end
@@ -5931,7 +5792,7 @@ module DataCache (
   input  wire          io_cpu_flush_valid,
   output wire          io_cpu_flush_ready,
   input  wire          io_cpu_flush_payload_singleLine,
-  input  wire [6:0]    io_cpu_flush_payload_lineId,
+  input  wire [4:0]    io_cpu_flush_payload_lineId,
   output wire          io_cpu_writesPending,
   output reg           io_mem_cmd_valid,
   input  wire          io_mem_cmd_ready,
@@ -5950,9 +5811,9 @@ module DataCache (
   input  wire          reset
 );
 
-  reg        [21:0]   ways_0_tags_spinal_port0;
+  reg        [23:0]   ways_0_tags_spinal_port0;
   reg        [31:0]   ways_0_data_spinal_port0;
-  wire       [21:0]   _zz_ways_0_tags_port;
+  wire       [23:0]   _zz_ways_0_tags_port;
   wire       [31:0]   _zz_stageB_amo_addSub;
   wire       [31:0]   _zz_stageB_amo_addSub_1;
   wire       [31:0]   _zz_stageB_amo_addSub_2;
@@ -5967,31 +5828,31 @@ module DataCache (
   reg                 _zz_2;
   wire                haltCpu;
   reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
+  reg        [4:0]    tagsReadCmd_payload;
   reg                 tagsWriteCmd_valid;
   reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg        [4:0]    tagsWriteCmd_payload_address;
   reg                 tagsWriteCmd_payload_data_valid;
   reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg        [21:0]   tagsWriteCmd_payload_data_address;
   reg                 tagsWriteLastCmd_valid;
   reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg        [4:0]    tagsWriteLastCmd_payload_address;
   reg                 tagsWriteLastCmd_payload_data_valid;
   reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg        [21:0]   tagsWriteLastCmd_payload_data_address;
   reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
+  reg        [7:0]    dataReadCmd_payload;
   reg                 dataWriteCmd_valid;
   reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [7:0]    dataWriteCmd_payload_address;
   reg        [31:0]   dataWriteCmd_payload_data;
   reg        [3:0]    dataWriteCmd_payload_mask;
   wire                _zz_ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_valid;
   wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_ways_0_tagsReadRsp_valid_1;
+  wire       [21:0]   ways_0_tagsReadRsp_address;
+  wire       [23:0]   _zz_ways_0_tagsReadRsp_valid_1;
   wire                _zz_ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRspMem;
   wire       [31:0]   ways_0_dataReadRsp;
@@ -6046,7 +5907,7 @@ module DataCache (
   wire                when_DataCache_l826;
   reg                 stageB_tagsReadRsp_0_valid;
   reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [21:0]   stageB_tagsReadRsp_0_address;
   wire                when_DataCache_l826_1;
   reg        [31:0]   stageB_dataReadRsp_0;
   wire                when_DataCache_l825;
@@ -6067,7 +5928,7 @@ module DataCache (
   wire       [31:0]   stageB_ioMemRspMuxed;
   reg                 stageB_flusher_waitDone;
   wire                stageB_flusher_hold;
-  reg        [7:0]    stageB_flusher_counter;
+  reg        [5:0]    stageB_flusher_counter;
   wire                when_DataCache_l855;
   wire                when_DataCache_l861;
   wire                when_DataCache_l863;
@@ -6120,11 +5981,11 @@ module DataCache (
   reg                 loader_valid_regNext;
   wire                when_DataCache_l1129;
   wire                when_DataCache_l1132;
-  reg [21:0] ways_0_tags [0:127];
-  reg [7:0] ways_0_data_symbol0 [0:1023];
-  reg [7:0] ways_0_data_symbol1 [0:1023];
-  reg [7:0] ways_0_data_symbol2 [0:1023];
-  reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [23:0] ways_0_tags [0:31];
+  reg [7:0] ways_0_data_symbol0 [0:255];
+  reg [7:0] ways_0_data_symbol1 [0:255];
+  reg [7:0] ways_0_data_symbol2 [0:255];
+  reg [7:0] ways_0_data_symbol3 [0:255];
   reg [7:0] _zz_ways_0_datasymbol_read;
   reg [7:0] _zz_ways_0_datasymbol_read_1;
   reg [7:0] _zz_ways_0_datasymbol_read_2;
@@ -6199,7 +6060,7 @@ module DataCache (
   assign _zz_ways_0_tagsReadRsp_valid_1 = ways_0_tags_spinal_port0;
   assign ways_0_tagsReadRsp_valid = _zz_ways_0_tagsReadRsp_valid_1[0];
   assign ways_0_tagsReadRsp_error = _zz_ways_0_tagsReadRsp_valid_1[1];
-  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[21 : 2];
+  assign ways_0_tagsReadRsp_address = _zz_ways_0_tagsReadRsp_valid_1[23 : 2];
   assign _zz_ways_0_dataReadRspMem = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
   assign ways_0_dataReadRspMem = ways_0_data_spinal_port0;
   assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
@@ -6213,9 +6074,9 @@ module DataCache (
   end
 
   always @(*) begin
-    tagsReadCmd_payload = 7'bxxxxxxx;
+    tagsReadCmd_payload = 5'bxxxxx;
     if(when_DataCache_l667) begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+      tagsReadCmd_payload = io_cpu_execute_address[9 : 5];
     end
   end
 
@@ -6227,9 +6088,9 @@ module DataCache (
   end
 
   always @(*) begin
-    dataReadCmd_payload = 10'bxxxxxxxxxx;
+    dataReadCmd_payload = 8'bxxxxxxxx;
     if(when_DataCache_l667) begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+      dataReadCmd_payload = io_cpu_execute_address[9 : 2];
     end
   end
 
@@ -6259,12 +6120,12 @@ module DataCache (
   end
 
   always @(*) begin
-    tagsWriteCmd_payload_address = 7'bxxxxxxx;
+    tagsWriteCmd_payload_address = 5'bxxxxx;
     if(when_DataCache_l855) begin
-      tagsWriteCmd_payload_address = stageB_flusher_counter[6:0];
+      tagsWriteCmd_payload_address = stageB_flusher_counter[4:0];
     end
     if(loader_done) begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[9 : 5];
     end
   end
 
@@ -6286,9 +6147,9 @@ module DataCache (
   end
 
   always @(*) begin
-    tagsWriteCmd_payload_data_address = 20'bxxxxxxxxxxxxxxxxxxxx;
+    tagsWriteCmd_payload_data_address = 22'bxxxxxxxxxxxxxxxxxxxxxx;
     if(loader_done) begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 10];
     end
   end
 
@@ -6336,12 +6197,12 @@ module DataCache (
   end
 
   always @(*) begin
-    dataWriteCmd_payload_address = 10'bxxxxxxxxxx;
+    dataWriteCmd_payload_address = 8'bxxxxxxxx;
     if(stageB_cpuWriteToCache) begin
-      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[9 : 2];
     end
     if(when_DataCache_l1097) begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[9 : 5],loader_counter_value};
     end
   end
 
@@ -6398,15 +6259,15 @@ module DataCache (
   end
 
   assign stage0_mask = (_zz_stage0_mask <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[9 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stage0_wayInvalidate = 1'b0;
   assign when_DataCache_l776 = (! io_cpu_memory_isStuck);
   assign when_DataCache_l776_1 = (! io_cpu_memory_isStuck);
   assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 10] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
   assign when_DataCache_l776_2 = (! io_cpu_memory_isStuck);
   assign when_DataCache_l776_3 = (! io_cpu_memory_isStuck);
-  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign _zz_stageA_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[9 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
   assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_stageA_dataColisions);
   assign when_DataCache_l827 = (! io_cpu_writeBack_isStuck);
   always @(*) begin
@@ -6485,10 +6346,10 @@ module DataCache (
   end
 
   assign stageB_flusher_hold = 1'b0;
-  assign when_DataCache_l855 = (! stageB_flusher_counter[7]);
+  assign when_DataCache_l855 = (! stageB_flusher_counter[5]);
   assign when_DataCache_l861 = (! stageB_flusher_hold);
   assign when_DataCache_l863 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
-  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[7]);
+  assign io_cpu_flush_ready = (stageB_flusher_waitDone && stageB_flusher_counter[5]);
   assign when_DataCache_l877 = (io_cpu_flush_valid && io_cpu_flush_payload_singleLine);
   assign when_DataCache_l885 = (io_cpu_writeBack_isValid && io_cpu_writeBack_isFiring);
   assign stageB_isExternalLsrc = 1'b0;
@@ -6783,7 +6644,7 @@ module DataCache (
     if(reset) begin
       memCmdSent <= 1'b0;
       stageB_flusher_waitDone <= 1'b0;
-      stageB_flusher_counter <= 8'h0;
+      stageB_flusher_counter <= 6'h0;
       stageB_flusher_start <= 1'b1;
       stageB_lrSc_reserved <= 1'b0;
       loader_valid <= 1'b0;
@@ -6803,16 +6664,16 @@ module DataCache (
       end
       if(when_DataCache_l855) begin
         if(when_DataCache_l861) begin
-          stageB_flusher_counter <= (stageB_flusher_counter + 8'h01);
+          stageB_flusher_counter <= (stageB_flusher_counter + 6'h01);
           if(when_DataCache_l863) begin
-            stageB_flusher_counter[7] <= 1'b1;
+            stageB_flusher_counter[5] <= 1'b1;
           end
         end
       end
       stageB_flusher_start <= (((((((! stageB_flusher_waitDone) && (! stageB_flusher_start)) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
       if(stageB_flusher_start) begin
         stageB_flusher_waitDone <= 1'b1;
-        stageB_flusher_counter <= 8'h0;
+        stageB_flusher_counter <= 6'h0;
         if(when_DataCache_l877) begin
           stageB_flusher_counter <= {1'b0,io_cpu_flush_payload_lineId};
         end
@@ -6863,256 +6724,142 @@ module DataCache (
 
 endmodule
 
-module InstructionCache (
+module StreamFifoLowLatency (
+  input  wire          io_push_valid,
+  output wire          io_push_ready,
+  input  wire          io_push_payload_error,
+  input  wire [31:0]   io_push_payload_inst,
+  output wire          io_pop_valid,
+  input  wire          io_pop_ready,
+  output wire          io_pop_payload_error,
+  output wire [31:0]   io_pop_payload_inst,
   input  wire          io_flush,
-  input  wire          io_cpu_prefetch_isValid,
-  output reg           io_cpu_prefetch_haltIt,
-  input  wire [31:0]   io_cpu_prefetch_pc,
-  input  wire          io_cpu_fetch_isValid,
-  input  wire          io_cpu_fetch_isStuck,
-  input  wire          io_cpu_fetch_isRemoved,
-  input  wire [31:0]   io_cpu_fetch_pc,
-  output wire [31:0]   io_cpu_fetch_data,
-  input  wire [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
-  input  wire          io_cpu_fetch_mmuRsp_isIoAccess,
-  input  wire          io_cpu_fetch_mmuRsp_isPaging,
-  input  wire          io_cpu_fetch_mmuRsp_allowRead,
-  input  wire          io_cpu_fetch_mmuRsp_allowWrite,
-  input  wire          io_cpu_fetch_mmuRsp_allowExecute,
-  input  wire          io_cpu_fetch_mmuRsp_exception,
-  input  wire          io_cpu_fetch_mmuRsp_refilling,
-  input  wire          io_cpu_fetch_mmuRsp_bypassTranslation,
-  output wire [31:0]   io_cpu_fetch_physicalAddress,
-  output wire          io_cpu_fetch_cacheMiss,
-  output wire          io_cpu_fetch_error,
-  output wire          io_cpu_fetch_mmuRefilling,
-  output wire          io_cpu_fetch_mmuException,
-  input  wire          io_cpu_fetch_isUser,
-  input  wire          io_cpu_decode_isValid,
-  input  wire          io_cpu_decode_isStuck,
-  input  wire [31:0]   io_cpu_decode_pc,
-  output wire [31:0]   io_cpu_decode_physicalAddress,
-  output wire [31:0]   io_cpu_decode_data,
-  input  wire          io_cpu_fill_valid,
-  input  wire [31:0]   io_cpu_fill_payload,
-  output wire          io_mem_cmd_valid,
-  input  wire          io_mem_cmd_ready,
-  output wire [31:0]   io_mem_cmd_payload_address,
-  output wire [2:0]    io_mem_cmd_payload_size,
-  input  wire          io_mem_rsp_valid,
-  input  wire [31:0]   io_mem_rsp_payload_data,
-  input  wire          io_mem_rsp_payload_error,
+  output wire [0:0]    io_occupancy,
+  output wire [0:0]    io_availability,
   input  wire          clk,
   input  wire          reset
 );
 
-  reg        [31:0]   banks_0_spinal_port1;
-  reg        [22:0]   ways_0_tags_spinal_port1;
-  wire       [22:0]   _zz_ways_0_tags_port;
-  reg                 _zz_1;
-  reg                 _zz_2;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [6:0]    lineLoader_flushCounter;
-  wire                when_InstructionCache_l338;
-  reg                 _zz_when_InstructionCache_l342;
-  wire                when_InstructionCache_l342;
-  wire                when_InstructionCache_l351;
-  reg                 lineLoader_cmdSent;
-  wire                io_mem_cmd_fire;
-  wire                when_Utils_l578;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [5:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [20:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [8:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                when_InstructionCache_l401;
-  wire       [8:0]    _zz_fetchStage_read_banksValue_0_dataMem;
-  wire                _zz_fetchStage_read_banksValue_0_dataMem_1;
-  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
-  wire       [31:0]   fetchStage_read_banksValue_0_data;
-  wire       [5:0]    _zz_fetchStage_read_waysValues_0_tag_valid;
-  wire                _zz_fetchStage_read_waysValues_0_tag_valid_1;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [20:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [22:0]   _zz_fetchStage_read_waysValues_0_tag_valid_2;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg [31:0] banks_0 [0:511];
-  reg [22:0] ways_0_tags [0:63];
+  wire                fifo_io_push_ready;
+  wire                fifo_io_pop_valid;
+  wire                fifo_io_pop_payload_error;
+  wire       [31:0]   fifo_io_pop_payload_inst;
+  wire       [0:0]    fifo_io_occupancy;
+  wire       [0:0]    fifo_io_availability;
 
-  assign _zz_ways_0_tags_port = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @(posedge clk) begin
-    if(_zz_1) begin
-      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
+  StreamFifo fifo (
+    .io_push_valid         (io_push_valid                 ), //i
+    .io_push_ready         (fifo_io_push_ready            ), //o
+    .io_push_payload_error (io_push_payload_error         ), //i
+    .io_push_payload_inst  (io_push_payload_inst[31:0]    ), //i
+    .io_pop_valid          (fifo_io_pop_valid             ), //o
+    .io_pop_ready          (io_pop_ready                  ), //i
+    .io_pop_payload_error  (fifo_io_pop_payload_error     ), //o
+    .io_pop_payload_inst   (fifo_io_pop_payload_inst[31:0]), //o
+    .io_flush              (io_flush                      ), //i
+    .io_occupancy          (fifo_io_occupancy             ), //o
+    .io_availability       (fifo_io_availability          ), //o
+    .clk                   (clk                           ), //i
+    .reset                 (reset                         )  //i
+  );
+  assign io_push_ready = fifo_io_push_ready;
+  assign io_pop_valid = fifo_io_pop_valid;
+  assign io_pop_payload_error = fifo_io_pop_payload_error;
+  assign io_pop_payload_inst = fifo_io_pop_payload_inst;
+  assign io_occupancy = fifo_io_occupancy;
+  assign io_availability = fifo_io_availability;
 
-  always @(posedge clk) begin
-    if(_zz_fetchStage_read_banksValue_0_dataMem_1) begin
-      banks_0_spinal_port1 <= banks_0[_zz_fetchStage_read_banksValue_0_dataMem];
-    end
-  end
+endmodule
 
-  always @(posedge clk) begin
-    if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_ways_0_tags_port;
-    end
-  end
+module StreamFifo (
+  input  wire          io_push_valid,
+  output reg           io_push_ready,
+  input  wire          io_push_payload_error,
+  input  wire [31:0]   io_push_payload_inst,
+  output reg           io_pop_valid,
+  input  wire          io_pop_ready,
+  output reg           io_pop_payload_error,
+  output reg  [31:0]   io_pop_payload_inst,
+  input  wire          io_flush,
+  output wire [0:0]    io_occupancy,
+  output wire [0:0]    io_availability,
+  input  wire          clk,
+  input  wire          reset
+);
 
-  always @(posedge clk) begin
-    if(_zz_fetchStage_read_waysValues_0_tag_valid_1) begin
-      ways_0_tags_spinal_port1 <= ways_0_tags[_zz_fetchStage_read_waysValues_0_tag_valid];
-    end
-  end
+  reg                 oneStage_doFlush;
+  wire                oneStage_buffer_valid;
+  wire                oneStage_buffer_ready;
+  wire                oneStage_buffer_payload_error;
+  wire       [31:0]   oneStage_buffer_payload_inst;
+  reg                 io_push_rValid;
+  reg                 io_push_rData_error;
+  reg        [31:0]   io_push_rData_inst;
+  wire                when_Stream_l375;
+  wire                when_Stream_l1230;
 
   always @(*) begin
-    _zz_1 = 1'b0;
-    if(lineLoader_write_data_0_valid) begin
-      _zz_1 = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    _zz_2 = 1'b0;
-    if(lineLoader_write_tag_0_valid) begin
-      _zz_2 = 1'b1;
-    end
-  end
-
-  always @(*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid) begin
-      if(when_InstructionCache_l401) begin
-        lineLoader_fire = 1'b1;
+    oneStage_doFlush = io_flush;
+    if(when_Stream_l1230) begin
+      if(io_pop_ready) begin
+        oneStage_doFlush = 1'b1;
       end
     end
   end
 
   always @(*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(when_InstructionCache_l338) begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(when_InstructionCache_l342) begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush) begin
-      io_cpu_prefetch_haltIt = 1'b1;
+    io_push_ready = oneStage_buffer_ready;
+    if(when_Stream_l375) begin
+      io_push_ready = 1'b1;
     end
   end
 
-  assign when_InstructionCache_l338 = (! lineLoader_flushCounter[6]);
-  assign when_InstructionCache_l342 = (! _zz_when_InstructionCache_l342);
-  assign when_InstructionCache_l351 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign io_mem_cmd_fire = (io_mem_cmd_valid && io_mem_cmd_ready);
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = 3'b101;
-  assign when_Utils_l578 = (! lineLoader_valid);
+  assign when_Stream_l375 = (! oneStage_buffer_valid);
+  assign oneStage_buffer_valid = io_push_rValid;
+  assign oneStage_buffer_payload_error = io_push_rData_error;
+  assign oneStage_buffer_payload_inst = io_push_rData_inst;
   always @(*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if(when_Utils_l578) begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    io_pop_valid = oneStage_buffer_valid;
+    if(when_Stream_l1230) begin
+      io_pop_valid = io_push_valid;
     end
   end
 
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[6]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[6] ? lineLoader_address[10 : 5] : lineLoader_flushCounter[5 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[6];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 11];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[10 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign when_InstructionCache_l401 = (lineLoader_wordIndex == 3'b111);
-  assign _zz_fetchStage_read_banksValue_0_dataMem = io_cpu_prefetch_pc[10 : 2];
-  assign _zz_fetchStage_read_banksValue_0_dataMem_1 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = banks_0_spinal_port1;
-  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
-  assign _zz_fetchStage_read_waysValues_0_tag_valid = io_cpu_prefetch_pc[10 : 5];
-  assign _zz_fetchStage_read_waysValues_0_tag_valid_1 = (! io_cpu_fetch_isStuck);
-  assign _zz_fetchStage_read_waysValues_0_tag_valid_2 = ways_0_tags_spinal_port1;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_fetchStage_read_waysValues_0_tag_valid_2[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_fetchStage_read_waysValues_0_tag_valid_2[1];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_fetchStage_read_waysValues_0_tag_valid_2[22 : 2];
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (|fetchStage_hit_hits_0);
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
-  assign io_cpu_fetch_cacheMiss = (! fetchStage_hit_valid);
-  assign io_cpu_fetch_error = (fetchStage_hit_error || ((! io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute))));
-  assign io_cpu_fetch_mmuRefilling = io_cpu_fetch_mmuRsp_refilling;
-  assign io_cpu_fetch_mmuException = (((! io_cpu_fetch_mmuRsp_refilling) && io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute)));
+  assign oneStage_buffer_ready = io_pop_ready;
+  always @(*) begin
+    io_pop_payload_error = oneStage_buffer_payload_error;
+    if(when_Stream_l1230) begin
+      io_pop_payload_error = io_push_payload_error;
+    end
+  end
+
+  always @(*) begin
+    io_pop_payload_inst = oneStage_buffer_payload_inst;
+    if(when_Stream_l1230) begin
+      io_pop_payload_inst = io_push_payload_inst;
+    end
+  end
+
+  assign io_occupancy = oneStage_buffer_valid;
+  assign io_availability = (! oneStage_buffer_valid);
+  assign when_Stream_l1230 = (! oneStage_buffer_valid);
   always @(posedge clk) begin
     if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= 3'b000;
+      io_push_rValid <= 1'b0;
     end else begin
-      if(lineLoader_fire) begin
-        lineLoader_valid <= 1'b0;
+      if(io_push_ready) begin
+        io_push_rValid <= io_push_valid;
       end
-      if(lineLoader_fire) begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid) begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush) begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(when_InstructionCache_l351) begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if(io_mem_cmd_fire) begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire) begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid) begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
-        if(io_mem_rsp_payload_error) begin
-          lineLoader_hadError <= 1'b1;
-        end
+      if(oneStage_doFlush) begin
+        io_push_rValid <= 1'b0;
       end
     end
   end
 
   always @(posedge clk) begin
-    if(io_cpu_fill_valid) begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(when_InstructionCache_l338) begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 7'h01);
-    end
-    _zz_when_InstructionCache_l342 <= lineLoader_flushCounter[6];
-    if(when_InstructionCache_l351) begin
-      lineLoader_flushCounter <= 7'h0;
+    if(io_push_ready) begin
+      io_push_rData_error <= io_push_payload_error;
+      io_push_rData_inst <= io_push_payload_inst;
     end
   end
 

--- a/gateware/src/vendor/soc/cpu/verilog/vexriscv/vexriscv_cynthion.yaml
+++ b/gateware/src/vendor/soc/cpu/verilog/vexriscv/vexriscv_cynthion.yaml
@@ -1,4 +1,1 @@
-iBus: !!vexriscv.BusReport
-  flushInstructions: [4111, 19, 19, 19]
-  info: !!vexriscv.CacheReport {bytePerLine: 32, size: 2048}
-  kind: cached
+{}

--- a/gateware/src/xbeam/fw/Cargo.toml
+++ b/gateware/src/xbeam/fw/Cargo.toml
@@ -20,3 +20,12 @@ heapless = "0.8.0"
 strum_macros = "0.26.4"
 strum = {version = "0.25.0", features = ["derive"], default-features=false}
 colorsys = { version = "*", default-features = false }
+
+[profile.release]
+codegen-units = 1
+debug = true
+debug-assertions = false
+incremental = false
+lto = true
+opt-level = "s"
+overflow-checks = false


### PR DESCRIPTION
* fix vexriscv sbt build scripts so its easier to modify in-place
* modify vexriscv configuration to remove icache, not necessary for any example bitstreams.
* reduce firmware bloat with cargo flags, and reduce sram size from 64K to 32K.
* remove `pre_main` for now as it seems to break under LTO. interestingly it doesn't seem to be necessary. maybe because icache is gone.