### PR TITLE
gateware: update testbenches, squash more amaranth 0.5 warnings.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
 
-  tests:
+  unit-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,17 @@ name: build & test
 on: [push]
 
 jobs:
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pdm-project/setup-pdm@v4
+      - run: |
+          pdm install
+          pdm test
+        working-directory: gateware
+
   ubuntu-usb-audio:
     runs-on: ubuntu-latest
     steps:

--- a/gateware/src/amaranth_future/fixed.py
+++ b/gateware/src/amaranth_future/fixed.py
@@ -1,12 +1,12 @@
 # from https://github.com/amaranth-lang/amaranth/pull/1005
 # slightly modified to work out-of-tree with Amaranth ~= 0.4
 
-from amaranth.hdl import ast
+from amaranth import hdl
 from amaranth.utils import bits_for
 
 __all__ = ["Shape", "SQ", "UQ", "Value", "Const"]
 
-class Shape(ast.ShapeCastable):
+class Shape(hdl.ShapeCastable):
     def __init__(self, i_or_f_width, f_width = None, /, *, signed):
         if f_width is None:
             self.i_width, self.f_width = 0, i_or_f_width
@@ -17,7 +17,7 @@ class Shape(ast.ShapeCastable):
 
     @staticmethod
     def cast(shape, f_width=0):
-        if not isinstance(shape, ast.Shape):
+        if not isinstance(shape, hdl.Shape):
             raise TypeError(f"Object {shape!r} cannot be converted to a fixed.Shape")
 
         # i_width is what's left after subtracting f_width and sign bit, but can't be negative.
@@ -26,7 +26,7 @@ class Shape(ast.ShapeCastable):
         return Shape(i_width, f_width, signed = shape.signed)
 
     def as_shape(self):
-        return ast.Shape(self.signed + self.i_width + self.f_width, self.signed)
+        return hdl.Shape(self.signed + self.i_width + self.f_width, self.signed)
 
     def __call__(self, target):
         return Value(self, target)
@@ -60,7 +60,7 @@ class UQ(Shape):
         super().__init__(*args, signed = False)
 
 
-class Value(ast.ValueCastable):
+class Value(hdl.ValueCastable):
     def __init__(self, shape, target):
         self._shape = shape
         self._target = target
@@ -72,16 +72,16 @@ class Value(ast.ValueCastable):
     def round(self, f_width=0):
         # If we're increasing precision, extend with more fractional bits.
         if f_width > self.f_width:
-            return Shape(self.i_width, f_width, signed = self.signed)(ast.Cat(ast.Const(0, f_width - self.f_width), self.sas_value()))
+            return Shape(self.i_width, f_width, signed = self.signed)(hdl.Cat(hdl.Const(0, f_width - self.f_width), self.raw()))
         
         # If we're reducing precision, truncate bits and add the top truncated bits for rounding.
         elif f_width < self.f_width:
-            return Shape(self.i_width, f_width, signed = self.signed)(self.sas_value()[self.f_width - f_width:] + self.sas_value()[self.f_width - f_width - 1])
+            return Shape(self.i_width, f_width, signed = self.signed)(self.raw()[self.f_width - f_width:] + self.raw()[self.f_width - f_width - 1])
 
         return self
 
     def truncate(self, f_width=0):
-        return Shape(self.i_width, f_width, signed = self.signed)(self.sas_value()[self.f_width - f_width:])
+        return Shape(self.i_width, f_width, signed = self.signed)(self.raw()[self.f_width - f_width:])
 
     @property
     def i_width(self):
@@ -95,13 +95,15 @@ class Value(ast.ValueCastable):
     def signed(self):
         return self._shape.signed
 
-    @ast.ValueCastable.lowermethod
     def as_value(self):
-        # FIXME For some reason lib.wiring breaks if we return
-        # signed values from here, not sure why.
         return self._target
 
-    def sas_value(self):
+    def raw(self):
+        """
+        Adding an `s ( )` signedness wrapper in `as_value` when needed
+        breaks lib.wiring for some reason. In the future, raw() and
+        `as_value()` should be combined.
+        """
         if self.signed:
             return self._target.as_signed()
         return self._target
@@ -111,8 +113,8 @@ class Value(ast.ValueCastable):
 
     def eq(self, other):
         # Regular values are assigned directly to the underlying value.
-        if isinstance(other, ast.Value):
-            return self.sas_value().eq(other)
+        if isinstance(other, hdl.Value):
+            return self.raw().eq(other)
 
         # int and float are cast to fixed.Const.
         elif isinstance(other, int) or isinstance(other, float):
@@ -125,11 +127,11 @@ class Value(ast.ValueCastable):
         # Match precision.
         other = other.round(self.f_width)
 
-        return self.sas_value().eq(other.sas_value())
+        return self.raw().eq(other.raw())
 
     def __mul__(self, other):
         # Regular values are cast to fixed.Value
-        if isinstance(other, ast.Value):
+        if isinstance(other, hdl.Value):
             other = Value.cast(other)
 
         # int are cast to fixed.Const
@@ -140,14 +142,14 @@ class Value(ast.ValueCastable):
         elif not isinstance(other, Value):
             raise TypeError(f"Object {other!r} cannot be converted to a fixed.Value")
 
-        return Value.cast(self.sas_value() * other.sas_value(), self.f_width + other.f_width)
+        return Value.cast(self.raw() * other.raw(), self.f_width + other.f_width)
 
     def __rmul__(self, other):
         return self.__mul__(other)
 
     def __add__(self, other):
         # Regular values are cast to fixed.Value
-        if isinstance(other, ast.Value):
+        if isinstance(other, hdl.Value):
             other = Value.cast(other)
 
         # int are cast to fixed.Const
@@ -160,14 +162,14 @@ class Value(ast.ValueCastable):
 
         f_width = max(self.f_width, other.f_width)
 
-        return Value.cast(self.round(f_width).sas_value() + other.round(f_width).sas_value(), f_width)
+        return Value.cast(self.round(f_width).raw() + other.round(f_width).raw(), f_width)
 
     def __radd__(self, other):
         return self.__add__(other)
 
     def __sub__(self, other):
         # Regular values are cast to fixed.Value
-        if isinstance(other, ast.Value):
+        if isinstance(other, hdl.Value):
             other = Value.cast(other)
 
         # int are cast to fixed.Const
@@ -180,7 +182,7 @@ class Value(ast.ValueCastable):
 
         f_width = max(self.f_width, other.f_width)
 
-        return Value.cast(self.round(f_width).sas_value() - other.round(f_width).sas_value(), f_width)
+        return Value.cast(self.round(f_width).raw() - other.round(f_width).raw(), f_width)
 
     def __rsub__(self, other):
         return -self.__sub__(other)
@@ -189,10 +191,10 @@ class Value(ast.ValueCastable):
         return self
     
     def __neg__(self):
-        return Value.cast(-self.sas_value(), self.f_width)
+        return Value.cast(-self.raw(), self.f_width)
 
     def __abs__(self):
-        return Value.cast(abs(self.sas_value()), self.f_width)
+        return Value.cast(abs(self.raw()), self.f_width)
 
     def __lshift__(self, other):
         if isinstance(other, int):
@@ -200,26 +202,26 @@ class Value(ast.ValueCastable):
                 raise ValueError("Shift amount cannot be negative")
 
             if other > self.f_width:
-                return Value.cast(ast.Cat(ast.Const(0, other - self.f_width), self.sas_value()))
+                return Value.cast(hdl.Cat(hdl.Const(0, other - self.f_width), self.raw()))
             else:
-                return Value.cast(self.sas_value(), self.f_width - other)
+                return Value.cast(self.raw(), self.f_width - other)
 
-        elif not isinstance(other, ast.Value):
+        elif not isinstance(other, hdl.Value):
             raise TypeError("Shift amount must be an integer value")
 
         if other.signed:
             raise TypeError("Shift amount must be unsigned")
 
-        return Value.cast(self.sas_value() << other, self.f_width)
+        return Value.cast(self.raw() << other, self.f_width)
 
     def __rshift__(self, other):
         if isinstance(other, int):
             if other < 0:
                 raise ValueError("Shift amount cannot be negative")
 
-            return Value.cast(self.sas_value(), self.f_width + other)
+            return Value.cast(self.raw(), self.f_width + other)
 
-        elif not isinstance(other, ast.Value):
+        elif not isinstance(other, hdl.Value):
             raise TypeError("Shift amount must be an integer value")
 
         if other.signed:
@@ -228,10 +230,10 @@ class Value(ast.ValueCastable):
         # Extend f_width by maximal shift amount.
         f_width = self.f_width + 2**other.width - 1
 
-        return Value.cast(self.round(f_width).sas_value() >> other, f_width)
+        return Value.cast(self.round(f_width).raw() >> other, f_width)
 
     def __lt__(self, other):
-        return self.__sub__(other).sas_value() < 0
+        return self.__sub__(other).raw() < 0
 
     def __ge__(self, other):
         return ~self.__lt__(other)
@@ -286,7 +288,7 @@ class Const(Value):
 
     @property
     def _target(self):
-        return ast.Const(self._value, self._shape.as_shape())
+        return hdl.Const(self._value, self._shape.as_shape())
 
     def as_integer_ratio(self):
         return self._value, 2**self.f_width

--- a/gateware/src/amaranth_future/fixed.py
+++ b/gateware/src/amaranth_future/fixed.py
@@ -320,6 +320,10 @@ class Const(Value):
         return self._value, 2**self.f_width
 
     def as_float(self):
-        return self._value / 2**self.f_width
+        if self._value > self._max_value():
+            v = self._min_value() + self._value - self._max_value()
+        else:
+            v = self._value
+        return v / 2**self.f_width
 
     # TODO: Operators

--- a/gateware/src/tiliqua/dsp.py
+++ b/gateware/src/tiliqua/dsp.py
@@ -365,7 +365,7 @@ class WaveShaper(wiring.Component):
                 if self.continuous:
                     m.d.comb += rport.addr.eq(x.truncate()+1)
                 else:
-                    with m.If((x.truncate()).sas_value() ==
+                    with m.If((x.truncate()).raw() ==
                               2**(self.lut_addr_width-1)-1):
                         m.d.comb += trunc.eq(1)
                         m.d.comb += rport.addr.eq(x.truncate())
@@ -1032,7 +1032,7 @@ class Boxcar(wiring.Component):
 
         # accumulator maintenance
         m.d.sync += fifo_r_en_l.eq(fifo.r_en)
-        m.d.comb += fifo_r_asq.sas_value().eq(fifo.r_data) # raw -> ASQ
+        m.d.comb += fifo_r_asq.raw().eq(fifo.r_data) # raw -> ASQ
         with m.If(self.i.valid & self.i.ready):
             with m.If(fifo_r_en_l):
                 # sample in + out simultaneously (normal case)

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -137,7 +137,7 @@ class EurorackPmod(wiring.Component):
     eeprom_serial: Out(32)
 
     # Bitwise manual LED overrides. 1 == audio passthrough, 0 == manual set.
-    led_mode: In(8, reset=0xff)
+    led_mode: In(8, init=0xff)
     # If an LED is in manual, this is signed i8 from -green to +red
     led: In(8).array(8)
 

--- a/gateware/src/tiliqua/i2c.py
+++ b/gateware/src/tiliqua/i2c.py
@@ -12,7 +12,7 @@ from amaranth.lib                import wiring
 from amaranth.lib.wiring         import Component, In, Out, flipped, connect
 from amaranth.lib.fifo           import SyncFIFO
 from amaranth_soc                import csr, gpio
-from luna.gateware.interface.i2c import I2CInitiator
+from vendor.i2c                  import I2CInitiator
 
 class PinSignature(wiring.Signature):
     def __init__(self):

--- a/gateware/src/tiliqua/raster.py
+++ b/gateware/src/tiliqua/raster.py
@@ -306,10 +306,10 @@ class Stroke(wiring.Component):
                 # Fired on every audio sample fs_strobe
                 with m.If(point_stream.valid):
                     m.d.sync += [
-                        sample_x.eq((point_stream.payload[0].sas_value()>>self.scale_x) + self.x_offset),
-                        sample_y.eq((point_stream.payload[1].sas_value()>>self.scale_y) + self.y_offset),
-                        sample_p.eq(point_stream.payload[2].sas_value()),
-                        sample_c.eq(point_stream.payload[3].sas_value()),
+                        sample_x.eq((point_stream.payload[0].raw()>>self.scale_x) + self.x_offset),
+                        sample_y.eq((point_stream.payload[1].raw()>>self.scale_y) + self.y_offset),
+                        sample_p.eq(point_stream.payload[2].raw()),
+                        sample_c.eq(point_stream.payload[3].raw()),
                         sample_intensity.eq(self.intensity),
                     ]
                     m.next = 'LATCH1'

--- a/gateware/src/tiliqua/scope.py
+++ b/gateware/src/tiliqua/scope.py
@@ -199,7 +199,7 @@ class ScopeTracePeripheral(wiring.Component):
                 m.d.sync += s.intensity.eq(self._intensity.f.intensity.w_data)
 
         with m.If(self._timebase.f.timebase.w_stb):
-            m.d.sync += self.timebase.sas_value().eq(self._timebase.f.timebase.w_data)
+            m.d.sync += self.timebase.raw().eq(self._timebase.f.timebase.w_data)
 
         with m.If(self._xscale.f.xscale.w_stb):
             for s in self.strokes:
@@ -210,7 +210,7 @@ class ScopeTracePeripheral(wiring.Component):
                 m.d.sync += s.scale_y.eq(self._yscale.f.yscale.w_data)
 
         with m.If(self._trigger_lvl.f.trigger_level.w_stb):
-            m.d.sync += self.trigger_lvl.sas_value().eq(self._trigger_lvl.f.trigger_level.w_data)
+            m.d.sync += self.trigger_lvl.raw().eq(self._trigger_lvl.f.trigger_level.w_data)
 
         for i, ypos_reg in enumerate(self._ypos):
             with m.If(ypos_reg.f.ypos.w_stb):

--- a/gateware/src/tiliqua/test_util.py
+++ b/gateware/src/tiliqua/test_util.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2024 Seb Holzapfel, apfelaudio UG <info@apfelaudio.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+"""
+Some utilities useful for unit testing Tiliqua components.
+"""
+
+def wb_transaction_params(register_start_bytes, field_start_bits,
+                          field_width_bits, word_sz=4):
+    """Convert register byte/bit indices into wishbone transaction arguments."""
+    # include bit offset in byte offset if it's > 8
+    register_start_bytes += field_start_bits // 8
+    field_start_bits %= 8
+    # compute minimum bytes needed to contain field (used for sel)
+    field_width_bytes_ceil  = field_width_bits // 8
+    if field_width_bits % 8 != 0:
+        field_width_bytes_ceil += 1
+    # field offset from the word, in bytes
+    ix_bytes = register_start_bytes % word_sz
+    # compute bus access
+    # FIXME: technically this may give us things like sel=0b0110,
+    # which probably no CPU would ever do...
+    wb_adr = register_start_bytes // word_sz
+    wb_sel = int('1'*field_width_bytes_ceil, base=2) << ix_bytes
+    # shift needed to pluck out field from wishbone dat_w, dat_r
+    dat_shift = ix_bytes*8 + field_start_bits
+    return wb_adr, wb_sel, dat_shift, field_width_bits
+
+def wb_register(mmap_bus, register_name, field_name=None):
+    """
+    Find a register (optionally subfield) in a bus memory map.
+    Return arguments required for a wishbone transaction to access it.
+    """
+    for (reg_object, name, (s_byte, e_byte)) in mmap_bus.memory_map.resources():
+        name = str(name)[6:-2]
+        if name == register_name:
+            if field_name is None:
+                return wb_transaction_params(
+                    register_start_bytes=s_byte,
+                    field_start_bits=0,
+                    field_width_bits=(e_byte - s_byte)*8
+                )
+            offset = 0
+            for path, action in reg_object:
+                name = "_".join([str(s) for s in path])
+                width = action.port.shape.width
+                if name == field_name:
+                    return wb_transaction_params(
+                        register_start_bytes=s_byte,
+                        field_start_bits=offset,
+                        field_width_bits=width
+                    )
+                offset += width
+    raise ValueError(f"{register_name} {field_name} does not exist in memory map.")
+
+async def wb_transaction(ctx, wb_bus, adr, we, sel, dat_w=None):
+    ctx.set(wb_bus.cyc, 1)
+    ctx.set(wb_bus.sel, sel)
+    ctx.set(wb_bus.we,  we)
+    ctx.set(wb_bus.adr, adr)
+    ctx.set(wb_bus.stb, 1)
+    if we:
+        ctx.set(wb_bus.dat_w, dat_w)
+    await ctx.tick().repeat(5)
+    assert ctx.get(wb_bus.ack) == 1
+    value = ctx.get(wb_bus.dat_r) if not we else None
+    ctx.set(wb_bus.stb, 0)
+    await ctx.tick()
+    assert ctx.get(wb_bus.ack) == 0
+    return value
+
+async def wb_csr_w(ctx, mmap_bus, wb_bus, value, register_name, field_name=None):
+    adr, sel, shift, _ = wb_register(mmap_bus, register_name, field_name)
+    return await wb_transaction(ctx, wb_bus, adr, 1, sel, dat_w=value<<shift)
+
+async def wb_csr_r(ctx, mmap_bus, wb_bus, register_name, field_name=None):
+    adr, sel, shift, w_bits = wb_register(mmap_bus, register_name, field_name)
+    value_32b = await wb_transaction(ctx, wb_bus, adr, 0, sel)
+    return (value_32b >> shift) & int('1'*w_bits, base=2)

--- a/gateware/src/top/dsp/top.py
+++ b/gateware/src/top/dsp/top.py
@@ -140,7 +140,7 @@ class Pitch(wiring.Component):
         m.d.comb += [
             split4.o[1].ready.eq(pitch_shift.i.ready),
             pitch_shift.i.valid.eq(split4.o[1].valid),
-            pitch_shift.i.payload.pitch.eq(split4.o[1].payload.sas_value() >> 8),
+            pitch_shift.i.payload.pitch.eq(split4.o[1].payload.raw() >> 8),
             pitch_shift.i.payload.grain_sz.eq(delay_line.max_delay//2),
         ]
 
@@ -351,7 +351,6 @@ class QuadNCO(wiring.Component):
             if x < clamp_lo:
                 x = clamp_lo
             out = volts_to_delta(x) * 16
-            print(x, volts_to_freq(x), out)
             return out
 
         m.submodules.v_oct = v_oct = dsp.WaveShaper(

--- a/gateware/src/top/polysyn/top.py
+++ b/gateware/src/top/polysyn/top.py
@@ -178,9 +178,9 @@ class PolySynth(wiring.Component):
                 # Filter cutoff on all channels is min(mod wheel, note velocity)
                 # Cutoff itself is smoothed by boxcars before being sent to SVF cutoff.
                 with m.If(last_cc1 < voice_tracker.o[n].payload.velocity):
-                    m.d.comb += boxcars[n].i.payload.sas_value().eq(last_cc1 << 4)
+                    m.d.comb += boxcars[n].i.payload.raw().eq(last_cc1 << 4)
                 with m.Else():
-                    m.d.comb += boxcars[n].i.payload.sas_value().eq(
+                    m.d.comb += boxcars[n].i.payload.raw().eq(
                             voice_tracker.o[n].payload.velocity << 4)
                 # Connect MIDI voice.note -> note to frequency LUT
                 m.d.comb += [
@@ -191,7 +191,7 @@ class PolySynth(wiring.Component):
                 # only first 6 channels touch sensitive
                 if n < 6:
                     with m.If(self.i_jack[n] == 0):
-                        m.d.comb += boxcars[n].i.payload.sas_value().eq(self.i_touch[n] << 3)
+                        m.d.comb += boxcars[n].i.payload.raw().eq(self.i_touch[n] << 3)
                     with m.Else():
                         m.d.comb += boxcars[n].i.payload.eq(0)
                 # Connect notes from fixed scale for touchsynth
@@ -212,7 +212,7 @@ class PolySynth(wiring.Component):
             # Connect voice.vel and NCO.o -> SVF.i
             dsp.connect_remap(m, ncos[n].o, svfs[n].i, lambda o, i : [
                 i.payload.x                    .eq(o.payload >> 1),
-                i.payload.resonance.sas_value().eq(self.reso),
+                i.payload.resonance.raw()      .eq(self.reso),
                 i.payload.cutoff               .eq(boxcars[n].o.payload) # hack
             ])
 
@@ -254,8 +254,8 @@ class PolySynth(wiring.Component):
         for lr in [0, 1]:
             dsp.connect_remap(m, hpf_split2.o[lr], output_hpfs[lr].i, lambda o, i : [
                 i.payload.x                     .eq(o.payload),
-                i.payload.cutoff.sas_value()    .eq(200),
-                i.payload.resonance.sas_value() .eq(20000),
+                i.payload.cutoff.raw()          .eq(200),
+                i.payload.resonance.raw()       .eq(20000),
             ])
 
             dsp.connect_remap(m, output_hpfs[lr].o, hpf_merge4.i[2+lr], lambda o, i : [

--- a/gateware/src/vendor/i2c.py
+++ b/gateware/src/vendor/i2c.py
@@ -1,0 +1,263 @@
+# Low-level I2C Initiator
+
+# From the Glasgow gateware, dual licensed under 0BSD or Apache-2.0.
+#
+# source: https://github.com/GlasgowEmbedded/glasgow
+# path: `glasgow/gateware/i2c.py`:
+#
+# I2C reference: https://www.nxp.com/docs/en/user-guide/UM10204.pdf
+
+from amaranth import *
+from amaranth.lib import io
+from amaranth.lib.cdc import FFSynchronizer
+
+
+class I2CBusDriver(Elaboratable):
+    """
+    Decodes bus conditions (start, stop, sample and setup) and provides synchronization.
+    """
+    def __init__(self, pads):
+        # TODO(amaranth 0.5+): migrate these to io.Buffer
+        self.scl_t  = pads.scl_t if hasattr(pads, "scl_t") else pads.scl
+        self.sda_t  = pads.sda_t if hasattr(pads, "sda_t") else pads.sda
+
+        self.scl_i  = Signal()
+        self.scl_o  = Signal(init=1)
+        self.sda_i  = Signal()
+        self.sda_o  = Signal(init=1)
+
+        self.sample = Signal(name="bus_sample")
+        self.setup  = Signal(name="bus_setup")
+        self.start  = Signal(name="bus_start")
+        self.stop   = Signal(name="bus_stop")
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # SDA line must be bidirectional...
+        m.d.comb += [
+            self.sda_t.o  .eq(0),
+            self.sda_t.oe .eq(~self.sda_o),
+        ]
+        m.submodules += FFSynchronizer(self.sda_t.i, self.sda_i, init=1)
+
+        # But the SCL line does not need to: only if we want to support clock stretching
+        if hasattr(self.scl_t, "oe"):
+            m.d.comb += [
+                self.scl_t.o  .eq(0),
+                self.scl_t.oe .eq(~self.scl_o),
+            ]
+            m.submodules += FFSynchronizer(self.scl_t.i, self.scl_i, init=1)
+        else:
+            # SCL output only
+            m.d.comb += [
+                self.scl_t.o  .eq(self.scl_o),
+                self.scl_i    .eq(self.scl_o),
+            ]
+
+        # Additional signals for bus state detection
+        scl_r = Signal(init=1)
+        sda_r = Signal(init=1)
+        m.d.sync += [
+            scl_r.eq(self.scl_i),
+            sda_r.eq(self.sda_i),
+        ]
+        m.d.comb += [
+            self.sample .eq(~scl_r & self.scl_i),  # SCL rising edge
+            self.setup  .eq(scl_r & ~self.scl_i),  # SCL falling edge
+            self.start  .eq(self.scl_i & sda_r & ~self.sda_i),  # SDA fall, SCL high
+            self.stop   .eq(self.scl_i & ~sda_r & self.sda_i),  # SDA rise, SCL high
+        ]
+
+        return m
+
+
+class I2CInitiator(Elaboratable):
+    """
+    Simple I2C transaction initiator.
+
+    Generates start and stop conditions, and transmits and receives octets.
+    Clock stretching is supported.
+
+    :param period_cyc:
+        Bus clock period, as a multiple of system clock period.
+    :type period_cyc: int
+    :param clk_stretch:
+        If true, SCL will be monitored for devices stretching the clock. Otherwise,
+        only internally generated SCL is considered.
+    :type clk_stretch: bool
+
+    :attr busy:
+        Busy flag. Low if the state machine is idle, high otherwise.
+    :attr start:
+        Start strobe. When ``busy`` is low, asserting ``start`` for one cycle generates
+        a start or repeated start condition on the bus. Ignored when ``busy`` is high.
+    :attr stop:
+        Stop strobe. When ``busy`` is low, asserting ``stop`` for one cycle generates
+        a stop condition on the bus. Ignored when ``busy`` is high.
+    :attr write:
+        Write strobe. When ``busy`` is low, asserting ``write`` for one cycle receives
+        an octet on the bus and latches it to ``data_o``, after which the acknowledge bit
+        is asserted if ``ack_i`` is high. Ignored when ``busy`` is high.
+    :attr data_i:
+        Data octet to be transmitted. Latched immediately after ``write`` is asserted.
+    :attr ack_o:
+        Received acknowledge bit.
+    :attr read:
+        Read strobe. When ``busy`` is low, asserting ``read`` for one cycle latches
+        ``data_i`` and transmits it on the bus, after which the acknowledge bit
+        from the bus is latched to ``ack_o``. Ignored when ``busy`` is high.
+    :attr data_o:
+        Received data octet.
+    :attr ack_i:
+        Acknowledge bit to be transmitted. Latched immediately after ``read`` is asserted.
+    """
+    def __init__(self, pads, period_cyc, clk_stretch=True):
+        self.period_cyc = int(period_cyc)
+        self.clk_stretch = clk_stretch
+
+        self.busy   = Signal(init=1)
+        self.start  = Signal()
+        self.stop   = Signal()
+        self.read   = Signal()
+        self.data_i = Signal(8)
+        self.ack_o  = Signal()
+        self.write  = Signal()
+        self.data_o = Signal(8)
+        self.ack_i  = Signal()
+
+        self.bus = I2CBusDriver(pads)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.bus = self.bus
+
+        timer = Signal(range(self.period_cyc))
+        stb   = Signal()
+
+        with m.If((timer == 0) | ~self.busy):
+            m.d.sync += timer.eq(self.period_cyc // 4)
+        with m.Elif((not self.clk_stretch) | (self.bus.scl_o == self.bus.scl_i)):
+            m.d.sync += timer.eq(timer - 1)
+        m.d.comb += stb.eq(timer == 0)
+
+        bitno   = Signal(range(8))
+        r_shreg = Signal(8)
+        w_shreg = Signal(8)
+        r_ack   = Signal()
+
+        with m.FSM() as fsm:
+            self._fsm = fsm
+            def scl_l(state, next_state, *exprs):
+                with m.State(state):
+                    with m.If(stb):
+                        m.d.sync += self.bus.scl_o.eq(0)
+                        m.next = next_state
+                        m.d.sync += exprs
+
+            def scl_h(state, next_state, *exprs):
+                with m.State(state):
+                    with m.If(stb):
+                        m.d.sync += self.bus.scl_o.eq(1)
+                    with m.Elif(self.bus.scl_o == 1):
+                        with m.If((not self.clk_stretch) | (self.bus.scl_i == 1)):
+                            m.next = next_state
+                            m.d.sync += exprs
+
+            def stb_x(state, next_state, *exprs, bit7_next_state=None):
+                with m.State(state):
+                    with m.If(stb):
+                        m.next = next_state
+                        if bit7_next_state is not None:
+                            with m.If(bitno == 7):
+                                m.next = bit7_next_state
+                        m.d.sync += exprs
+
+            with m.State("IDLE"):
+                m.d.sync += self.busy.eq(1)
+                with m.If(self.start):
+                    with m.If(self.bus.scl_i & self.bus.sda_i):
+                        m.next = "START-SDA-L"
+                    with m.Elif(~self.bus.scl_i):
+                        m.next = "START-SCL-H"
+                    with m.Elif(self.bus.scl_i):
+                        m.next = "START-SCL-L"
+                with m.Elif(self.stop):
+                    with m.If(self.bus.scl_i & ~self.bus.sda_o):
+                        m.next = "STOP-SDA-H"
+                    with m.Elif(~self.bus.scl_i):
+                        m.next = "STOP-SCL-H"
+                    with m.Elif(self.bus.scl_i):
+                        m.next = "STOP-SCL-L"
+                with m.Elif(self.write):
+                    m.d.sync += w_shreg.eq(self.data_i)
+                    m.next = "WRITE-DATA-SCL-L"
+                with m.Elif(self.read):
+                    m.d.sync += r_ack.eq(self.ack_i)
+                    m.next = "READ-DATA-SCL-L"
+                with m.Else():
+                    m.d.sync += self.busy.eq(0)
+
+            # start
+            scl_l("START-SCL-L", "START-SDA-H")
+            stb_x("START-SDA-H", "START-SCL-H",
+                self.bus.sda_o.eq(1)
+            )
+            scl_h("START-SCL-H", "START-SDA-L")
+            stb_x("START-SDA-L", "IDLE",
+                self.bus.sda_o.eq(0)
+            )
+            # stop
+            scl_l("STOP-SCL-L",  "STOP-SDA-L")
+            stb_x("STOP-SDA-L",  "STOP-SCL-H",
+                self.bus.sda_o.eq(0)
+            )
+            scl_h("STOP-SCL-H",  "STOP-SDA-H")
+            stb_x("STOP-SDA-H",  "IDLE",
+                self.bus.sda_o.eq(1)
+            )
+            # write data
+            scl_l("WRITE-DATA-SCL-L", "WRITE-DATA-SDA-X")
+            stb_x("WRITE-DATA-SDA-X", "WRITE-DATA-SCL-H",
+                self.bus.sda_o.eq(w_shreg[7])
+            )
+            scl_h("WRITE-DATA-SCL-H", "WRITE-DATA-SDA-N",
+                w_shreg.eq(Cat(C(0, 1), w_shreg[0:7]))
+            )
+            stb_x("WRITE-DATA-SDA-N", "WRITE-DATA-SCL-L",
+                bitno.eq(bitno + 1),
+                bit7_next_state="WRITE-ACK-SCL-L"
+            )
+            # write ack
+            scl_l("WRITE-ACK-SCL-L", "WRITE-ACK-SDA-H")
+            stb_x("WRITE-ACK-SDA-H", "WRITE-ACK-SCL-H",
+                self.bus.sda_o.eq(1)
+            )
+            scl_h("WRITE-ACK-SCL-H", "WRITE-ACK-SDA-N",
+                self.ack_o.eq(~self.bus.sda_i)
+            )
+            stb_x("WRITE-ACK-SDA-N", "IDLE")
+            # read data
+            scl_l("READ-DATA-SCL-L", "READ-DATA-SDA-H")
+            stb_x("READ-DATA-SDA-H", "READ-DATA-SCL-H",
+                self.bus.sda_o.eq(1)
+            )
+            scl_h("READ-DATA-SCL-H", "READ-DATA-SDA-N",
+                r_shreg.eq(Cat(self.bus.sda_i, r_shreg[0:7]))
+            )
+            stb_x("READ-DATA-SDA-N", "READ-DATA-SCL-L",
+                bitno.eq(bitno + 1),
+                bit7_next_state="READ-ACK-SCL-L"
+            )
+            # read ack
+            scl_l("READ-ACK-SCL-L", "READ-ACK-SDA-X")
+            stb_x("READ-ACK-SDA-X", "READ-ACK-SCL-H",
+                self.bus.sda_o.eq(~r_ack)
+            )
+            scl_h("READ-ACK-SCL-H", "READ-ACK-SDA-N",
+                self.data_o.eq(r_shreg)
+            )
+            stb_x("READ-ACK-SDA-N", "IDLE")
+
+        return m

--- a/gateware/tests/test_i2c.py
+++ b/gateware/tests/test_i2c.py
@@ -30,95 +30,111 @@ class I2CTests(unittest.TestCase):
         bridge = wishbone.WishboneCSRBridge(decoder.bus, data_width=32)
         m.submodules += [dut, decoder, bridge]
 
-        def register_ix(register_name, field_name=None):
-            for (reg_object, name, (s_byte, e_byte)) in dut.bus.memory_map.resources():
+        def wb_transaction_params(register_start_bytes, field_start_bits,
+                                  field_width_bits, word_sz=4):
+            """Convert register byte/bit indices into wishbone transaction arguments."""
+            # include bit offset in byte offset if it's > 8
+            register_start_bytes += field_start_bits // 8
+            field_start_bits %= 8
+            # compute minimum bytes needed to contain field (used for sel)
+            field_width_bytes_ceil  = field_width_bits // 8
+            if field_width_bits % 8 != 0:
+                field_width_bytes_ceil += 1
+            # field offset from the word, in bytes
+            ix_bytes = register_start_bytes % word_sz
+            # compute bus access
+            # FIXME: technically this may give us things like sel=0b0110,
+            # which probably no CPU would ever do...
+            wb_adr = register_start_bytes // word_sz
+            wb_sel = int('1'*field_width_bytes_ceil, base=2) << ix_bytes
+            # shift needed to pluck out field from wishbone dat_w, dat_r
+            dat_shift = ix_bytes*8 + field_start_bits
+            return wb_adr, wb_sel, dat_shift, field_width_bits
+
+        def wb_register(mmap_bus, register_name, field_name=None):
+            """
+            Find a register (optionally subfield) in a bus memory map.
+            Return arguments required for a wishbone transaction to access it.
+            """
+            for (reg_object, name, (s_byte, e_byte)) in mmap_bus.memory_map.resources():
                 name = str(name)[6:-2]
                 if name == register_name:
                     if field_name is None:
-                        return s_byte, 0, (e_byte - s_byte)*8
+                        return wb_transaction_params(
+                            register_start_bytes=s_byte,
+                            field_start_bits=0,
+                            field_width_bits=(e_byte - s_byte)*8
+                        )
                     offset = 0
                     for path, action in reg_object:
                         name = "_".join([str(s) for s in path])
                         width = action.port.shape.width
                         if name == field_name:
-                            return s_byte, offset, width
+                            return wb_transaction_params(
+                                register_start_bytes=s_byte,
+                                field_start_bits=offset,
+                                field_width_bits=width
+                            )
                         offset += width
             raise ValueError(f"{register_name} {field_name} does not exist in memory map.")
 
-        async def wb_transaction(ctx, adr, we, sel, dat_w=None):
-            ctx.set(bridge.wb_bus.cyc, 1)
-            ctx.set(bridge.wb_bus.sel, sel)
-            ctx.set(bridge.wb_bus.we,  we)
-            ctx.set(bridge.wb_bus.adr, adr)
-            ctx.set(bridge.wb_bus.stb, 1)
+        async def wb_transaction(ctx, wb_bus, adr, we, sel, dat_w=None):
+            ctx.set(wb_bus.cyc, 1)
+            ctx.set(wb_bus.sel, sel)
+            ctx.set(wb_bus.we,  we)
+            ctx.set(wb_bus.adr, adr)
+            ctx.set(wb_bus.stb, 1)
             if we:
-                ctx.set(bridge.wb_bus.dat_w, dat_w)
+                ctx.set(wb_bus.dat_w, dat_w)
             await ctx.tick().repeat(5)
-            self.assertEqual(ctx.get(bridge.wb_bus.ack), 1)
-            value = ctx.get(bridge.wb_bus.dat_r) if not we else None
-            ctx.set(bridge.wb_bus.stb, 0)
+            self.assertEqual(ctx.get(wb_bus.ack), 1)
+            value = ctx.get(wb_bus.dat_r) if not we else None
+            ctx.set(wb_bus.stb, 0)
             await ctx.tick()
-            self.assertEqual(ctx.get(bridge.wb_bus.ack), 0)
+            self.assertEqual(ctx.get(wb_bus.ack), 0)
             return value
 
-        async def wb_csr_w(ctx, value, register_name, field_name=None):
-            s_bytes, s_bits, w_bits = register_ix(register_name, field_name)
+        async def wb_csr_w(ctx, mmap_bus, wb_bus, value, register_name, field_name=None):
+            adr, sel, shift, _ = wb_register(mmap_bus, register_name, field_name)
+            return await wb_transaction(ctx, wb_bus, adr, 1, sel, dat_w=value<<shift)
 
-            # constrain ix_bits in 0..7, add rest to s_bytes
-            s_bytes += s_bits // 8
-            ix_bits  = s_bits % 8
-            ix_bytes = s_bytes % 4
-            w_bytes  = w_bits // 8
-            if w_bits % 8 != 0:
-                w_bytes += 1
-
-            # compute bus access
-            adr = s_bytes // 4
-            dat_w = (value << ix_bytes) << ix_bits
-            sel = int('1'*w_bytes, base=2) << ix_bytes
-
-            return await wb_transaction(ctx, adr, 1, sel, dat_w)
-
-        async def wb_csr_r(ctx, register_name, field_name=None):
-            s_bytes, s_bits, w_bits = register_ix(register_name, field_name)
-
-            # constrain ix_bits in 0..7, add rest to s_bytes
-            s_bytes += s_bits // 8
-            ix_bits  = s_bits % 8
-            ix_bytes = s_bytes % 4
-
-            # compute bus access
-            adr = s_bytes // 4
-            sel = 0b1111
-
-            value_32b = await wb_transaction(ctx, adr, 0, sel)
-            return ((value_32b >> ix_bytes) >> ix_bits) & int('1'*w_bits, base=2)
+        async def wb_csr_r(ctx, mmap_bus, wb_bus, register_name, field_name=None):
+            adr, sel, shift, w_bits = wb_register(mmap_bus, register_name, field_name)
+            value_32b = await wb_transaction(ctx, wb_bus, adr, 0, sel)
+            return (value_32b >> shift) & int('1'*w_bits, base=2)
 
         async def testbench(ctx):
+
+            async def csr_write(ctx, value, register, field=None):
+                await wb_csr_w(ctx, dut.bus, bridge.wb_bus, value, register, field)
+
+            async def csr_read(ctx, register, field=None):
+                return await wb_csr_r(ctx, dut.bus, bridge.wb_bus, register, field)
+
             # set device address
-            await wb_csr_w(ctx,  0x55, "address")
+            await csr_write(ctx, 0x55, "address")
 
             # enqueue 2x write ops
-            await wb_csr_w(ctx, 0x042, "transaction_reg")
-            await wb_csr_w(ctx, 0x013, "transaction_reg")
+            await csr_write(ctx, 0x042, "transaction_reg")
+            await csr_write(ctx, 0x013, "transaction_reg")
 
             # enqueue 1x read op
-            await wb_csr_w(ctx, 0x100, "transaction_reg")
+            await csr_write(ctx, 0x100, "transaction_reg")
 
             # 3 transactions are enqueued
             self.assertEqual(ctx.get(dut._transactions.level), 3)
 
             # start the i2c core
-            await wb_csr_w(ctx,     1, "start")
+            await csr_write(ctx,     1, "start")
 
             # busy flag should go high
-            self.assertEqual(await wb_csr_r(ctx, "status", "busy"), 1)
+            self.assertEqual(await csr_read(ctx, "status", "busy"), 1)
 
             # run for a while
             await ctx.tick().repeat(500)
 
             # busy flag should be low
-            self.assertEqual(await wb_csr_r(ctx, "status", "busy"), 0)
+            self.assertEqual(await csr_read(ctx, "status", "busy"), 0)
 
             # all transactions drained.
             self.assertEqual(ctx.get(dut._transactions.level), 0)

--- a/gateware/tests/test_i2c.py
+++ b/gateware/tests/test_i2c.py
@@ -3,7 +3,7 @@ import unittest
 from amaranth              import *
 from amaranth.sim          import *
 from amaranth.lib          import wiring
-from tiliqua               import i2c
+from tiliqua               import i2c, test_util
 
 from amaranth_soc          import csr
 from amaranth_soc.csr      import wishbone
@@ -30,86 +30,15 @@ class I2CTests(unittest.TestCase):
         bridge = wishbone.WishboneCSRBridge(decoder.bus, data_width=32)
         m.submodules += [dut, decoder, bridge]
 
-        def wb_transaction_params(register_start_bytes, field_start_bits,
-                                  field_width_bits, word_sz=4):
-            """Convert register byte/bit indices into wishbone transaction arguments."""
-            # include bit offset in byte offset if it's > 8
-            register_start_bytes += field_start_bits // 8
-            field_start_bits %= 8
-            # compute minimum bytes needed to contain field (used for sel)
-            field_width_bytes_ceil  = field_width_bits // 8
-            if field_width_bits % 8 != 0:
-                field_width_bytes_ceil += 1
-            # field offset from the word, in bytes
-            ix_bytes = register_start_bytes % word_sz
-            # compute bus access
-            # FIXME: technically this may give us things like sel=0b0110,
-            # which probably no CPU would ever do...
-            wb_adr = register_start_bytes // word_sz
-            wb_sel = int('1'*field_width_bytes_ceil, base=2) << ix_bytes
-            # shift needed to pluck out field from wishbone dat_w, dat_r
-            dat_shift = ix_bytes*8 + field_start_bits
-            return wb_adr, wb_sel, dat_shift, field_width_bits
-
-        def wb_register(mmap_bus, register_name, field_name=None):
-            """
-            Find a register (optionally subfield) in a bus memory map.
-            Return arguments required for a wishbone transaction to access it.
-            """
-            for (reg_object, name, (s_byte, e_byte)) in mmap_bus.memory_map.resources():
-                name = str(name)[6:-2]
-                if name == register_name:
-                    if field_name is None:
-                        return wb_transaction_params(
-                            register_start_bytes=s_byte,
-                            field_start_bits=0,
-                            field_width_bits=(e_byte - s_byte)*8
-                        )
-                    offset = 0
-                    for path, action in reg_object:
-                        name = "_".join([str(s) for s in path])
-                        width = action.port.shape.width
-                        if name == field_name:
-                            return wb_transaction_params(
-                                register_start_bytes=s_byte,
-                                field_start_bits=offset,
-                                field_width_bits=width
-                            )
-                        offset += width
-            raise ValueError(f"{register_name} {field_name} does not exist in memory map.")
-
-        async def wb_transaction(ctx, wb_bus, adr, we, sel, dat_w=None):
-            ctx.set(wb_bus.cyc, 1)
-            ctx.set(wb_bus.sel, sel)
-            ctx.set(wb_bus.we,  we)
-            ctx.set(wb_bus.adr, adr)
-            ctx.set(wb_bus.stb, 1)
-            if we:
-                ctx.set(wb_bus.dat_w, dat_w)
-            await ctx.tick().repeat(5)
-            self.assertEqual(ctx.get(wb_bus.ack), 1)
-            value = ctx.get(wb_bus.dat_r) if not we else None
-            ctx.set(wb_bus.stb, 0)
-            await ctx.tick()
-            self.assertEqual(ctx.get(wb_bus.ack), 0)
-            return value
-
-        async def wb_csr_w(ctx, mmap_bus, wb_bus, value, register_name, field_name=None):
-            adr, sel, shift, _ = wb_register(mmap_bus, register_name, field_name)
-            return await wb_transaction(ctx, wb_bus, adr, 1, sel, dat_w=value<<shift)
-
-        async def wb_csr_r(ctx, mmap_bus, wb_bus, register_name, field_name=None):
-            adr, sel, shift, w_bits = wb_register(mmap_bus, register_name, field_name)
-            value_32b = await wb_transaction(ctx, wb_bus, adr, 0, sel)
-            return (value_32b >> shift) & int('1'*w_bits, base=2)
-
         async def testbench(ctx):
 
             async def csr_write(ctx, value, register, field=None):
-                await wb_csr_w(ctx, dut.bus, bridge.wb_bus, value, register, field)
+                await test_util.wb_csr_w(
+                        ctx, dut.bus, bridge.wb_bus, value, register, field)
 
             async def csr_read(ctx, register, field=None):
-                return await wb_csr_r(ctx, dut.bus, bridge.wb_bus, register, field)
+                return await test_util.wb_csr_r(
+                        ctx, dut.bus, bridge.wb_bus, register, field)
 
             # set device address
             await csr_write(ctx, 0x55, "address")

--- a/gateware/tests/test_i2c.py
+++ b/gateware/tests/test_i2c.py
@@ -2,7 +2,11 @@ import unittest
 
 from amaranth              import *
 from amaranth.sim          import *
+from amaranth.lib          import wiring
 from tiliqua               import i2c
+
+from amaranth_soc          import csr
+from amaranth_soc.csr      import wishbone
 
 class I2CTests(unittest.TestCase):
 
@@ -19,72 +23,108 @@ class I2CTests(unittest.TestCase):
 
         i2c_pads = FakeI2CPads()
 
-        top = i2c.I2CPeripheral(pads=i2c_pads, period_cyc=4)
+        m = Module()
+        dut = i2c.Peripheral(pads=i2c_pads, period_cyc=4)
+        decoder = csr.Decoder(addr_width=28, data_width=8)
+        decoder.add(dut.bus, addr=0, name="dut")
+        bridge = wishbone.WishboneCSRBridge(decoder.bus, data_width=32)
+        m.submodules += [dut, decoder, bridge]
 
-        def testbench():
-            # initial
-            yield Tick()
+        def register_ix(register_name, field_name=None):
+            for (reg_object, name, (s_byte, e_byte)) in dut.bus.memory_map.resources():
+                name = str(name)[6:-2]
+                if name == register_name:
+                    if field_name is None:
+                        return s_byte, 0, (e_byte - s_byte)*8
+                    offset = 0
+                    for path, action in reg_object:
+                        name = "_".join([str(s) for s in path])
+                        width = action.port.shape.width
+                        if name == field_name:
+                            return s_byte, offset, width
+                        offset += width
+            raise ValueError(f"{register_name} {field_name} does not exist in memory map.")
 
+        async def wb_transaction(ctx, adr, we, sel, dat_w=None):
+            ctx.set(bridge.wb_bus.cyc, 1)
+            ctx.set(bridge.wb_bus.sel, sel)
+            ctx.set(bridge.wb_bus.we,  we)
+            ctx.set(bridge.wb_bus.adr, adr)
+            ctx.set(bridge.wb_bus.stb, 1)
+            if we:
+                ctx.set(bridge.wb_bus.dat_w, dat_w)
+            await ctx.tick().repeat(5)
+            self.assertEqual(ctx.get(bridge.wb_bus.ack), 1)
+            value = ctx.get(bridge.wb_bus.dat_r) if not we else None
+            ctx.set(bridge.wb_bus.stb, 0)
+            await ctx.tick()
+            self.assertEqual(ctx.get(bridge.wb_bus.ack), 0)
+            return value
+
+        async def wb_csr_w(ctx, value, register_name, field_name=None):
+            s_bytes, s_bits, w_bits = register_ix(register_name, field_name)
+
+            # constrain ix_bits in 0..7, add rest to s_bytes
+            s_bytes += s_bits // 8
+            ix_bits  = s_bits % 8
+            ix_bytes = s_bytes % 4
+            w_bytes  = w_bits // 8
+            if w_bits % 8 != 0:
+                w_bytes += 1
+
+            # compute bus access
+            adr = s_bytes // 4
+            dat_w = (value << ix_bytes) << ix_bits
+            sel = int('1'*w_bytes, base=2) << ix_bytes
+
+            return await wb_transaction(ctx, adr, 1, sel, dat_w)
+
+        async def wb_csr_r(ctx, register_name, field_name=None):
+            s_bytes, s_bits, w_bits = register_ix(register_name, field_name)
+
+            # constrain ix_bits in 0..7, add rest to s_bytes
+            s_bytes += s_bits // 8
+            ix_bits  = s_bits % 8
+            ix_bytes = s_bytes % 4
+
+            # compute bus access
+            adr = s_bytes // 4
+            sel = 0b1111
+
+            value_32b = await wb_transaction(ctx, adr, 0, sel)
+            return ((value_32b >> ix_bytes) >> ix_bits) & int('1'*w_bits, base=2)
+
+        async def testbench(ctx):
             # set device address
-            yield top._address.w_stb               .eq(1)
-            yield top._address.w_data              .eq(0x55)
-            yield Tick()
+            await wb_csr_w(ctx,  0x55, "address")
 
             # enqueue 2x write ops
-            yield top._transaction_data.w_stb      .eq(1)
-            yield top._transaction_data.w_data     .eq(0x042)
-            yield Tick()
-            yield top._transaction_data.w_stb      .eq(1)
-            yield top._transaction_data.w_data     .eq(0x013)
-            yield Tick()
+            await wb_csr_w(ctx, 0x042, "transaction_reg")
+            await wb_csr_w(ctx, 0x013, "transaction_reg")
 
             # enqueue 1x read op
-            yield top._transaction_data.w_stb      .eq(1)
-            yield top._transaction_data.w_data     .eq(0x100)
-            yield Tick()
+            await wb_csr_w(ctx, 0x100, "transaction_reg")
 
-            # stop enqueueing ops
-            yield top._transaction_data.w_stb      .eq(0)
-            yield top._transaction_data.w_data     .eq(0)
-            yield Tick()
+            # 3 transactions are enqueued
+            self.assertEqual(ctx.get(dut._transactions.level), 3)
 
             # start the i2c core
-            yield top._start.w_stb .eq(1)
-            yield top._start.w_data.eq(1)
-            yield Tick()
+            await wb_csr_w(ctx,     1, "start")
 
-            # run until it's done
-            for _ in range(600):
-                yield Tick()
-            assert (yield top._busy.r_data == 0)
+            # busy flag should go high
+            self.assertEqual(await wb_csr_r(ctx, "status", "busy"), 1)
 
-            # new device address
-            yield Tick()
-            yield top._address.w_stb               .eq(1)
-            yield top._address.w_data              .eq(0x07)
+            # run for a while
+            await ctx.tick().repeat(500)
 
-            # enqueue 1x read op
-            yield top._transaction_data.w_stb      .eq(1)
-            yield top._transaction_data.w_data     .eq(0x100)
-            yield Tick()
+            # busy flag should be low
+            self.assertEqual(await wb_csr_r(ctx, "status", "busy"), 0)
 
-            # enqueue 1x write op
-            yield top._transaction_data.w_stb      .eq(1)
-            yield top._transaction_data.w_data     .eq(0x022)
-            yield Tick()
+            # all transactions drained.
+            self.assertEqual(ctx.get(dut._transactions.level), 0)
 
-            # start the i2c core
-            yield top._start.w_stb .eq(1)
-            yield top._start.w_data.eq(1)
-            yield Tick()
-
-            # run until it's done
-            for _ in range(600):
-                yield Tick()
-            assert (yield top._busy.r_data == 0)
-
-        sim = Simulator(top)
+        sim = Simulator(m)
         sim.add_clock(1e-6)
-        sim.add_process(testbench)
+        sim.add_testbench(testbench)
         with sim.write_vcd(vcd_file=open("test_i2c_tx.vcd", "w")):
             sim.run()


### PR DESCRIPTION
* update all unit testbenches to amaranth 0.5, add to CI
* add utilities for testing wishbone transactions against amaranth-soc peripherals (and i2c example)
* switch from `ast` to `hdl` top-level library where possible to squash amaranth 0.5 warnings
* switch i2c implementation from luna to glasgow implementation to squash Record warnings.