### PR TITLE
cache/delay_line: improvements for psram-backed pitch shifting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,9 @@ jobs:
             override: True
             components: rustfmt, clippy, llvm-tools
             target: riscv32imac-unknown-none-elf
-      - run: cargo install cargo-binutils svd2rust form
+      - run: cargo install cargo-binutils form
+      # https://github.com/rust-embedded/svd2rust/issues/863
+      - run: cargo install svd2rust --locked
       - run: git submodule update --init --recursive
       - run: yosys --version
       - run: |
@@ -131,7 +133,8 @@ jobs:
             override: True
             components: rustfmt, clippy, llvm-tools
             target: riscv32imac-unknown-none-elf
-      - run: cargo install cargo-binutils svd2rust form
+      - run: cargo install cargo-binutils form
+      - run: cargo install svd2rust --locked
       - run: git submodule update --init --recursive
       - run: yosys --version
       - run: |
@@ -156,7 +159,8 @@ jobs:
             override: True
             components: rustfmt, clippy, llvm-tools
             target: riscv32imac-unknown-none-elf
-      - run: cargo install cargo-binutils svd2rust form
+      - run: cargo install cargo-binutils form
+      - run: cargo install svd2rust --locked
       - run: git submodule update --init --recursive
       - run: yosys --version
       - run: |
@@ -197,7 +201,8 @@ jobs:
             override: True
             components: rustfmt, clippy, llvm-tools
             target: riscv32imac-unknown-none-elf
-      - run: cargo install cargo-binutils svd2rust form
+      - run: cargo install cargo-binutils form
+      - run: cargo install svd2rust --locked
       - run: git submodule update --init --recursive
       - run: yosys --version
       - run: |

--- a/gateware/pdm.lock
+++ b/gateware/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:486d56919edc12aec3276313c746426c3208d7fb43ebc47a0e85175a074d4af0"
+content_hash = "sha256:0241dcdde7dbb85dc826294f63e6599d9ef24bb755d57e8b98ced64464e7ddd6"
 
 [[metadata.targets]]
 requires_python = ">=3.9,<=3.11"
@@ -702,6 +702,17 @@ groups = ["default", "docs", "test"]
 files = [
     {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
     {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
+]
+
+[[package]]
+name = "parameterized"
+version = "0.9.0"
+requires_python = ">=3.7"
+summary = "Parameterized testing with any Python test framework"
+groups = ["default"]
+files = [
+    {file = "parameterized-0.9.0-py2.py3-none-any.whl", hash = "sha256:4e0758e3d41bea3bbd05ec14fc2c24736723f243b28d702081aef438c9372b1b"},
+    {file = "parameterized-0.9.0.tar.gz", hash = "sha256:7fc905272cefa4f364c1a3429cbbe9c0f98b793988efb5bf90aac80f08db09b1"},
 ]
 
 [[package]]

--- a/gateware/pyproject.toml
+++ b/gateware/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "luna-usb @ git+https://github.com/schnommus/luna@seb/iso-amaranth5",
     "scipy>=1.9.3",
     "matplotlib>=3.9.0",
+    "parameterized>=0.9.0",
 ]
 
 [tool.pdm.dev-dependencies]

--- a/gateware/src/tiliqua/cache.py
+++ b/gateware/src/tiliqua/cache.py
@@ -95,7 +95,7 @@ class WishboneL2Cache(wiring.Component):
         m.submodules.data_mem = data_mem = Memory(
             shape=unsigned(self.data_width), depth=2**linebits*self.burst_len, init=[])
         wr_port = data_mem.write_port(granularity=self.granularity)
-        rd_port = data_mem.read_port(transparent_for=(wr_port,))
+        rd_port = data_mem.read_port(domain='comb')
 
         write_from_slave = Signal()
 

--- a/gateware/src/tiliqua/cache.py
+++ b/gateware/src/tiliqua/cache.py
@@ -54,10 +54,11 @@ class WishboneL2Cache(wiring.Component):
         # store if burst_len == 1, but this cache will always issue bursts.
         assert burst_len > 1
 
-        # DPRAM-backed cache works on delay line demos but seems to show
-        # artifacts when used in the video frontend. So there is likely
-        # bug in this, haven't tracked it down yet. Prohibit usage for now.
-        assert lutram_backed
+        if not lutram_backed:
+            print()
+            print("WARN: DPRAM-backed cache healthy in delay line tests but shows "
+                  "artifacts when used in the video frontend. So there is likely a "
+                  "bug in this, haven't tracked it down yet.")
 
         self.cachesize_words = cachesize_words
         self.data_width      = data_width

--- a/gateware/src/tiliqua/cache.py
+++ b/gateware/src/tiliqua/cache.py
@@ -23,7 +23,8 @@ class WishboneL2Cache(wiring.Component):
     - 'direct-mapped': https://en.wikipedia.org/wiki/Cache_placement_policies
     - 'write-back': https://en.wikipedia.org/wiki/Cache_(computing)#Writing_policies
 
-    The 'master' bus is for the wishbone master that uses the cache.
+    The 'master' bus is for the wishbone master that uses the cache. It may only
+    issue classic transactions (i.e no burst transactions).
     The 'slave' bus is for the backing store. The cache acts as a master on
     this bus in order to fill / evict cache lines. The cache will issue burst
     transactions of length `burst_len` whenever a cache line is to be evicted
@@ -53,8 +54,9 @@ class WishboneL2Cache(wiring.Component):
         # store if burst_len == 1, but this cache will always issue bursts.
         assert burst_len > 1
 
-        # DPRAM-backed cache works on delay line demos but seems to glitch
-        # when used in the video frontent. Prohibit its use for now.
+        # DPRAM-backed cache works on delay line demos but seems to show
+        # artifacts when used in the video frontend. So there is likely
+        # bug in this, haven't tracked it down yet. Prohibit usage for now.
         assert lutram_backed
 
         self.cachesize_words = cachesize_words

--- a/gateware/tests/test_delayln.py
+++ b/gateware/tests/test_delayln.py
@@ -105,7 +105,7 @@ class DelayLineTests(unittest.TestCase):
             ctx.set(tap1.o.ready, 1)
             for n in range(0, sys.maxsize):
                 ctx.set(tap1.i.valid, 1)
-                ctx.set(tap1.i.payload, 4)
+                ctx.set(tap1.i.payload, 150)
                 await ctx.tick()
                 ctx.set(tap1.i.valid, 0)
                 await ctx.tick().repeat(30)
@@ -114,7 +114,7 @@ class DelayLineTests(unittest.TestCase):
             ctx.set(tap2.o.ready, 1)
             for n in range(0, sys.maxsize):
                 ctx.set(tap2.i.valid, 1)
-                ctx.set(tap2.i.payload, 200)
+                ctx.set(tap2.i.payload, 220)
                 await ctx.tick()
                 ctx.set(tap2.i.valid, 0)
                 await ctx.tick().repeat(30)
@@ -137,7 +137,7 @@ class DelayLineTests(unittest.TestCase):
                         print("write", hex(mem[adr]), "@", adr)
                     else:
                         print("read", hex(mem[adr]), "@", adr)
-                        ctx.set(membus.dat_r, mem[ctx.get(membus.adr)])
+                        ctx.set(membus.dat_r, mem[adr])
                     await ctx.tick()
                     adr += 1
                 assert adr - adr_start == dut._cache.burst_len

--- a/gateware/tests/test_delayln.py
+++ b/gateware/tests/test_delayln.py
@@ -6,6 +6,8 @@ import math
 import sys
 import unittest
 
+from parameterized import parameterized
+
 from amaranth              import *
 from amaranth.sim          import *
 from amaranth.lib          import wiring
@@ -20,22 +22,43 @@ from amaranth_future       import fixed
 
 class DelayLineTests(unittest.TestCase):
 
-    def test_psram_delayln(self):
+    @parameterized.expand([
+        ["b4_c64_lr_short_taps", 64,  4, True,  256, 1,   3],
+        ["b4_c16_lr_long_taps",  16,  4, True,  256, 150, 220],
+        ["b4_c64_lr_long_taps",  64,  4, True,  256, 150, 220],
+        ["b4_c256_lr_long_taps", 256, 4, True,  256, 150, 220],
+        ["b4_c64_lr_endpoints1", 64,  4, True,  256, 0,   255],
+        ["b4_c64_lr_endpoints2", 64,  4, True,  256, 255, 0],
+        ["b8_c64_lr_long_taps",  64,  8, True,  256, 150, 220],
+        ["b4_c64_dp_short_taps", 64,  4, False, 256, 1,   3],
+        ["b4_c64_dp_long_taps",  64,  4, False, 256, 150, 220],
+        ["b8_c64_dp_long_taps",  64,  8, False, 256, 150, 220],
+    ])
+    def test_psram_delayln(self, name, cachesize_words, cache_burst_len, cache_lutram_backed,
+                           max_delay, tap1_delay, tap2_delay):
+
+        cache_kwargs = {
+            "lutram_backed":   cache_lutram_backed,
+            "burst_len":       cache_burst_len,
+            "cachesize_words": cachesize_words,
+        }
 
         dut = delay_line.DelayLine(
-            max_delay=256,
+            max_delay=max_delay,
             psram_backed=True,
             base=0x0,
             addr_width_o=22,
             write_triggers_read=True,
+            cache_kwargs=cache_kwargs,
         )
 
-        tap1 = dut.add_tap(fixed_delay=150)
-        tap2 = dut.add_tap(fixed_delay=220)
+        tap1 = dut.add_tap(fixed_delay=tap1_delay)
+        tap2 = dut.add_tap(fixed_delay=tap2_delay)
 
         def stimulus_values():
             for n in range(0, sys.maxsize):
                 yield fixed.Const(0.8*math.sin(n*0.2), shape=ASQ)
+
 
         async def stimulus_i(ctx):
             """Send `stimulus_values` to the DUT."""
@@ -54,26 +77,19 @@ class DelayLineTests(unittest.TestCase):
                 n_samples_o = 0
                 ctx.set(tap.o.ready, 1)
                 while True:
-                    # there must be a more idiomatic way to write this kind of stuff..
-                    async for _, _, valid, payload in ctx.tick().sample(
-                            tap.o.valid, tap.o.payload):
-                        if valid:
-                            if n_samples_o >= tap.fixed_delay:
-                                self.assertEqual(payload.__repr__(),
-                                                 next(s).__repr__())
-                            else:
-                                self.assertEqual(payload.__repr__(),
-                                                 fixed.Const(0, shape=ASQ).__repr__())
-                            n_samples_o += 1
+                    await ctx.tick().until(tap.o.valid)
+                    expected_payload = next(s) if n_samples_o >= tap.fixed_delay else fixed.Const(0, shape=ASQ)
+                    assert ctx.get(tap.o.payload == expected_payload)
+                    n_samples_o += 1
             return _validate_tap
 
-        async def psram_testbench(ctx):
-            """Simulate DelayLine against a fake PSRAM bus."""
+        async def psram_simulation(ctx):
+            """Simulate a fake PSRAM bus."""
             mem = [0] * dut.max_delay
             membus = dut.bus
-            for _ in range(100):
-                while not ctx.get(membus.stb):
-                    await ctx.tick()
+            # Respond to memory transactions forever
+            while True:
+                await ctx.tick().until(membus.stb)
                 adr = adr_start = ctx.get(membus.adr)
                 # Simulate ACKs delayed from stb (like real memory)
                 await ctx.tick().repeat(8)
@@ -81,7 +97,6 @@ class DelayLineTests(unittest.TestCase):
                 if ctx.get(membus.we):
                     while ctx.get(membus.cti == wishbone.CycleType.INCR_BURST):
                         mem[adr] = ctx.get(membus.dat_w)
-                        print("write", hex(mem[adr]), "@", adr)
                         await ctx.tick()
                         ctx.set(membus.ack, 1)
                         adr += 1
@@ -89,7 +104,6 @@ class DelayLineTests(unittest.TestCase):
                 else:
                     ctx.set(membus.ack, 1)
                     while ctx.get(membus.stb):
-                        print("read", hex(mem[adr]), "@", adr)
                         ctx.set(membus.dat_r, mem[adr])
                         await ctx.tick()
                         adr += 1
@@ -97,13 +111,51 @@ class DelayLineTests(unittest.TestCase):
                 ctx.set(membus.ack, 0)
                 await ctx.tick()
 
+        async def testbench(ctx):
+            """Top-level testbench."""
+
+            n_samples_in    = 0
+            n_samples_tap1  = 0
+            n_samples_tap2  = 0
+
+            n_write_bursts  = 0
+            n_read_bursts   = 0
+
+            for _ in range(max_delay*20):
+                n_samples_in    += ctx.get(dut.i.valid & dut.i.ready)
+                n_samples_tap1  += ctx.get(tap1.o.valid & tap1.o.ready)
+                n_samples_tap2  += ctx.get(tap2.o.valid & tap2.o.ready)
+                n_write_bursts  += ctx.get(dut.bus.we  & (dut.bus.cti == wishbone.CycleType.END_OF_BURST))
+                n_read_bursts   += ctx.get(~dut.bus.we & (dut.bus.cti == wishbone.CycleType.END_OF_BURST))
+                await ctx.tick()
+
+            print()
+            print("n_samples_in",   n_samples_in)
+            print("n_samples_tap1", n_samples_tap1)
+            print("n_samples_tap2", n_samples_tap2)
+            print("n_write_bursts", n_write_bursts)
+            print("n_read_bursts",  n_read_bursts)
+
+            samples_per_burst = (n_samples_in + n_samples_tap1 + n_samples_tap2) / (n_write_bursts + n_read_bursts)
+
+            print("samples_per_burst", samples_per_burst)
+
+            assert n_samples_in > 100
+            assert abs(n_samples_in - n_samples_tap1) < 2
+            assert abs(n_samples_in - n_samples_tap2) < 2
+
+            if cachesize_words > 64:
+                # arbitrarily chosen based on current cache performance
+                assert samples_per_burst > 2 * cache_burst_len
+
         sim = Simulator(dut)
         sim.add_clock(1e-6)
         sim.add_process(stimulus_i)
-        sim.add_process(validate_tap(tap1))
-        sim.add_process(validate_tap(tap2))
-        sim.add_testbench(psram_testbench)
-        with sim.write_vcd(vcd_file=open("test_psram_delayln.vcd", "w")):
+        sim.add_testbench(validate_tap(tap1), background=True)
+        sim.add_testbench(validate_tap(tap2), background=True)
+        sim.add_testbench(psram_simulation,   background=True)
+        sim.add_testbench(testbench)
+        with sim.write_vcd(vcd_file=open(f"test_psram_delayln_{name}.vcd", "w")):
             sim.run()
 
     def test_sram_delayln(self):

--- a/gateware/tests/test_delayln.py
+++ b/gateware/tests/test_delayln.py
@@ -20,6 +20,92 @@ from amaranth_future       import fixed
 
 class DelayLineTests(unittest.TestCase):
 
+    def test_psram_delayln(self):
+
+        dut = delay_line.DelayLine(
+            max_delay=256,
+            psram_backed=True,
+            base=0x0,
+            addr_width_o=22,
+            write_triggers_read=True,
+        )
+
+        tap1 = dut.add_tap(fixed_delay=150)
+        tap2 = dut.add_tap(fixed_delay=220)
+
+        def stimulus_values():
+            for n in range(0, sys.maxsize):
+                yield fixed.Const(0.8*math.sin(n*0.2), shape=ASQ)
+
+        async def stimulus_i(ctx):
+            """Send `stimulus_values` to the DUT."""
+            s = stimulus_values()
+            while True:
+                await ctx.tick().until(dut.i.ready)
+                ctx.set(dut.i.valid, 1)
+                ctx.set(dut.i.payload, next(s))
+                await ctx.tick()
+                ctx.set(dut.i.valid, 0)
+
+        def validate_tap(tap):
+            """Verify tap outputs exactly match a delayed stimulus."""
+            async def _validate_tap(ctx):
+                s = stimulus_values()
+                n_samples_o = 0
+                ctx.set(tap.o.ready, 1)
+                while True:
+                    # there must be a more idiomatic way to write this kind of stuff..
+                    async for _, _, valid, payload in ctx.tick().sample(
+                            tap.o.valid, tap.o.payload):
+                        if valid:
+                            if n_samples_o >= tap.fixed_delay:
+                                self.assertEqual(payload.__repr__(),
+                                                 next(s).__repr__())
+                            else:
+                                self.assertEqual(payload.__repr__(),
+                                                 fixed.Const(0, shape=ASQ).__repr__())
+                            n_samples_o += 1
+            return _validate_tap
+
+        async def psram_testbench(ctx):
+            """Simulate DelayLine against a fake PSRAM bus."""
+            mem = [0] * dut.max_delay
+            membus = dut.bus
+            for _ in range(100):
+                while not ctx.get(membus.stb):
+                    await ctx.tick()
+                adr = adr_start = ctx.get(membus.adr)
+                # Simulate ACKs delayed from stb (like real memory)
+                await ctx.tick().repeat(8)
+                # warn: only whole-word transactions are simulated
+                if ctx.get(membus.we):
+                    while ctx.get(membus.cti == wishbone.CycleType.INCR_BURST):
+                        mem[adr] = ctx.get(membus.dat_w)
+                        print("write", hex(mem[adr]), "@", adr)
+                        await ctx.tick()
+                        ctx.set(membus.ack, 1)
+                        adr += 1
+                    await ctx.tick()
+                else:
+                    ctx.set(membus.ack, 1)
+                    while ctx.get(membus.stb):
+                        print("read", hex(mem[adr]), "@", adr)
+                        ctx.set(membus.dat_r, mem[adr])
+                        await ctx.tick()
+                        adr += 1
+                assert adr - adr_start == dut._cache.burst_len
+                ctx.set(membus.ack, 0)
+                await ctx.tick()
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_process(stimulus_i)
+        sim.add_process(validate_tap(tap1))
+        sim.add_process(validate_tap(tap2))
+        sim.add_testbench(psram_testbench)
+        with sim.write_vcd(vcd_file=open("test_psram_delayln.vcd", "w")):
+            sim.run()
+
     def test_sram_delayln(self):
 
         dut = delay_line.DelayLine(
@@ -77,65 +163,4 @@ class DelayLineTests(unittest.TestCase):
         sim.add_process(stimulus_rd1)
         sim.add_process(stimulus_rd2)
         with sim.write_vcd(vcd_file=open("test_sram_delayln.vcd", "w")):
-            sim.run()
-
-    def test_psram_delayln(self):
-
-        dut = delay_line.DelayLine(
-            max_delay=256,
-            psram_backed=True,
-            base=0x0,
-            addr_width_o=22,
-            write_triggers_read=True,
-        )
-
-        tap1 = dut.add_tap(fixed_delay=150)
-        tap2 = dut.add_tap(fixed_delay=220)
-
-        async def stimulus_wr(ctx):
-            for n in range(0, sys.maxsize):
-                ctx.set(dut.i.valid, 1)
-                ctx.set(dut.i.payload,
-                        fixed.Const(0.8*math.sin(n*0.2), shape=ASQ))
-                await ctx.tick()
-                ctx.set(dut.i.valid, 0)
-                await ctx.tick().repeat(30)
-
-        async def testbench(ctx):
-            # Simulate some transactions against a fake PSRAM bus.
-            mem = [0] * dut.max_delay
-            membus = dut.bus
-            ctx.set(tap1.o.ready, 1)
-            ctx.set(tap2.o.ready, 1)
-            for _ in range(100):
-                while not ctx.get(membus.stb):
-                    await ctx.tick()
-                adr = adr_start = ctx.get(membus.adr)
-                # Simulate acks delayed from stb
-                # warn: only whole-word transactions are simulated
-                await ctx.tick().repeat(8)
-                if ctx.get(membus.we):
-                    while ctx.get(membus.cti == wishbone.CycleType.INCR_BURST):
-                        mem[adr] = ctx.get(membus.dat_w)
-                        print("write", hex(mem[adr]), "@", adr)
-                        await ctx.tick()
-                        ctx.set(membus.ack, 1)
-                        adr += 1
-                    await ctx.tick()
-                else:
-                    ctx.set(membus.ack, 1)
-                    while ctx.get(membus.stb):
-                        print("read", hex(mem[adr]), "@", adr)
-                        ctx.set(membus.dat_r, mem[adr])
-                        await ctx.tick()
-                        adr += 1
-                assert adr - adr_start == dut._cache.burst_len
-                ctx.set(membus.ack, 0)
-                await ctx.tick()
-
-        sim = Simulator(dut)
-        sim.add_clock(1e-6)
-        sim.add_testbench(testbench)
-        sim.add_process(stimulus_wr)
-        with sim.write_vcd(vcd_file=open("test_psram_delayln.vcd", "w")):
             sim.run()

--- a/gateware/tests/test_delayln.py
+++ b/gateware/tests/test_delayln.py
@@ -114,7 +114,7 @@ class DelayLineTests(unittest.TestCase):
             ctx.set(tap2.o.ready, 1)
             for n in range(0, sys.maxsize):
                 ctx.set(tap2.i.valid, 1)
-                ctx.set(tap2.i.payload, 10)
+                ctx.set(tap2.i.payload, 200)
                 await ctx.tick()
                 ctx.set(tap2.i.valid, 0)
                 await ctx.tick().repeat(30)


### PR DESCRIPTION
A bunch of improvements to `DelayLine` & `Cache` to facilitate psram-backed pitch shifting:
- `cache`: reduce memory access port shape to 32-bit always (fix RAM inference)
- `cache`: add switch to select LUTRAM or dual-port RAM as backing store
- `delayline`: fix logic where zero delay is requested
- `test_delayln`: parameterize test cases and add more coverage
- `top/dsp`: modify `pitch` example to be PSRAM-backed with much longer grain size