### PR TITLE
dsp: implement polyphase resampler

### DIFF
--- a/gateware/src/tiliqua/dsp.py
+++ b/gateware/src/tiliqua/dsp.py
@@ -784,6 +784,9 @@ class FIR(wiring.Component):
     Filter order must be of the form :py:`2**N`, to allow for efficient
     implementation of index wrapping (internal memory sizes power of 2).
 
+    This filter contains some optional optimizations to act as an efficient
+    interpolator. See the documentation on the :py:`stride` argument below.
+
     Members
     -------
     i : :py:`In(stream.Signature(ASQ))`
@@ -821,6 +824,16 @@ class FIR(wiring.Component):
             All taps are scaled by :py:`prescale`. This is used in cases where
             you are upsampling and need to preserve energy. Be careful with this,
             it can overflow the tap coefficients (you'll get a warning).
+        stride : int
+            When an FIR filter is used as an interpolator, a common pattern is
+            to provide 1 'actual' sample and pad S-1 zeroes for every S
+            output samples needed. For any :py:`stride > 1`, the :py:`stride`
+            must evenly divide :py:`filter_order` (i.e. no remainder). For
+            :py:`stride > 1`, this core applies some optimizations, assuming
+            every S'th sample is nonzero, and the rest are zero. This results in
+            a factor S reduction in MAC ops (latency) and a factor S reduction in
+            RAM needed for sample storage. The tap storage remains of size
+            :py:`filter_order` as all taps are still mathematically required.
         """
         order_needed = 2**ceil_log2(filter_order)
         if order_needed != filter_order:

--- a/gateware/src/tiliqua/dsp.py
+++ b/gateware/src/tiliqua/dsp.py
@@ -1004,6 +1004,7 @@ class Resample(wiring.Component):
             Expected sample rate of incoming samples, used for calculating filter coefficients.
         n_up : int
             Numerator of the resampling ratio. Samples are produced at :py:`fs_in * (n_up / m_down)`.
+            FIXME: must be a power of 2 due to FIR implementation details.
         m_down : int
             Denominator of the resampling ratio. Samples are produced at :py:`fs_in * (n_up / m_down)`.
         bw : float

--- a/gateware/src/tiliqua/dsp.py
+++ b/gateware/src/tiliqua/dsp.py
@@ -1013,8 +1013,8 @@ class Resample(wiring.Component):
         gcd = math.gcd(n_up, m_down)
         if gcd > 1:
             print(f"WARN: Resample {n_up}/{m_down} has GCD {gcd}. Using {n_up/gcd}/{m_down/gcd}.")
-            n_up = n_up/gcd
-            m_down = m_down/gcd
+            n_up = n_up//gcd
+            m_down = m_down//gcd
 
         self.fs_in  = fs_in
         self.n_up   = n_up

--- a/gateware/tests/test_dsp.py
+++ b/gateware/tests/test_dsp.py
@@ -91,8 +91,10 @@ class DSPTests(unittest.TestCase):
 
     @parameterized.expand([
         ["dual_sine_n4_m1", 100, 4, 1, 0.001, lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
-        # TODO: fix alignment of downsample reference waveform.
+        # TODO: looks correct, fix alignment of reference waveform and reduce tolerance.
         ["dual_sine_n1_m4", 100, 1, 4, 0.1,   lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
+        # TODO: looks correct, fix alignment of reference waveform and reduce tolerance.
+        ["dual_sine_n2_m3", 100, 2, 3, 0.25,  lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
     ])
     def test_resample(self, name, n_samples, n_up, m_down, tolerance, stimulus_function):
 

--- a/gateware/tests/test_dsp.py
+++ b/gateware/tests/test_dsp.py
@@ -73,7 +73,7 @@ class DSPTests(unittest.TestCase):
                 if o_sample:
                     # Verify latency and value of the payload is as we expect.
                     #assert n_latency == expected_latency
-                    assert abs(ctx.get(dut.o.payload).as_float() - y_expected[n_samples_out]) < 0.005
+                    #assert abs(ctx.get(dut.o.payload).as_float() - y_expected[n_samples_out]) < 0.005
                     n_samples_out += 1
                     if n_samples_out == len(y_expected):
                         break

--- a/gateware/tests/test_dsp.py
+++ b/gateware/tests/test_dsp.py
@@ -73,7 +73,7 @@ class DSPTests(unittest.TestCase):
                 if o_sample:
                     # Verify latency and value of the payload is as we expect.
                     #assert n_latency == expected_latency
-                    #assert abs(ctx.get(dut.o.payload).as_float() - y_expected[n_samples_out]) < 0.005
+                    assert abs(ctx.get(dut.o.payload).as_float() - y_expected[n_samples_out]) < 0.005
                     n_samples_out += 1
                     if n_samples_out == len(y_expected):
                         break

--- a/gateware/tests/test_dsp.py
+++ b/gateware/tests/test_dsp.py
@@ -24,17 +24,17 @@ class DSPTests(unittest.TestCase):
 
 
     @parameterized.expand([
-        ["dual_sine_small",   100, 16, 1, lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
-        ["dual_sine_large",   100, 64, 1, lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
-        ["impulse_small",     100, 16, 1, lambda n: 0.95 if n == 0 else 0.0],
-        ["sine_interpolator_s1", 100, 16, 1, lambda n: 0.9*math.sin(n*0.2) if n % 4 == 0 else 0.0],
-        ["sine_interpolator_s4", 100, 16, 4, lambda n: 0.9*math.sin(n*0.2) if n % 4 == 0 else 0.0],
+        ["dual_sine_small",      100, 16, 1, 17, lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
+        ["dual_sine_large",      100, 64, 1, 65, lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
+        ["impulse_small",        100, 16, 1, 17, lambda n: 0.95 if n == 0 else 0.0],
+        ["sine_interpolator_s1", 100, 16, 1, 17, lambda n: 0.9*math.sin(n*0.2) if n % 4 == 0 else 0.0],
+        ["sine_interpolator_s2", 100, 16, 2, 9,  lambda n: 0.9*math.sin(n*0.2) if n % 4 == 0 else 0.0],
+        ["sine_interpolator_s4", 100, 16, 4, 5,  lambda n: 0.9*math.sin(n*0.2) if n % 4 == 0 else 0.0],
     ])
-    def test_fir(self, name, n_samples, n_order, stride, stimulus_function):
+    def test_fir(self, name, n_samples, n_order, stride, expected_latency, stimulus_function):
 
         dut = dsp.FIR(fs=48000, filter_cutoff_hz=2000,
                       filter_order=n_order, stride=stride)
-        expected_latency = n_order + 1
 
         def stimulus_values():
             """Create fixed-point samples to stimulate the DUT."""
@@ -72,7 +72,7 @@ class DSPTests(unittest.TestCase):
                     n_latency     = 0
                 if o_sample:
                     # Verify latency and value of the payload is as we expect.
-                    #assert n_latency == expected_latency
+                    assert n_latency == expected_latency
                     assert abs(ctx.get(dut.o.payload).as_float() - y_expected[n_samples_out]) < 0.005
                     n_samples_out += 1
                     if n_samples_out == len(y_expected):

--- a/gateware/tests/test_dsp.py
+++ b/gateware/tests/test_dsp.py
@@ -24,14 +24,16 @@ class DSPTests(unittest.TestCase):
 
 
     @parameterized.expand([
-        ["dual_sine_small", 100, 16,  lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
-        ["dual_sine_large", 100, 64,  lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
-        ["impulse_small",   100, 16,  lambda n: 0.95 if n == 0 else 0.0],
+        ["dual_sine_small",   100, 16, 1, lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
+        ["dual_sine_large",   100, 64, 1, lambda n: 0.4*(math.sin(n*0.2) + math.sin(n))],
+        ["impulse_small",     100, 16, 1, lambda n: 0.95 if n == 0 else 0.0],
+        ["sine_interpolator_s1", 100, 16, 1, lambda n: 0.9*math.sin(n*0.2) if n % 4 == 0 else 0.0],
+        ["sine_interpolator_s4", 100, 16, 4, lambda n: 0.9*math.sin(n*0.2) if n % 4 == 0 else 0.0],
     ])
-    def test_fir(self, name, n_samples, n_order, stimulus_function):
+    def test_fir(self, name, n_samples, n_order, stride, stimulus_function):
 
         dut = dsp.FIR(fs=48000, filter_cutoff_hz=2000,
-                      filter_order=n_order)
+                      filter_order=n_order, stride=stride)
         expected_latency = n_order + 1
 
         def stimulus_values():
@@ -70,7 +72,7 @@ class DSPTests(unittest.TestCase):
                     n_latency     = 0
                 if o_sample:
                     # Verify latency and value of the payload is as we expect.
-                    assert n_latency == expected_latency
+                    #assert n_latency == expected_latency
                     assert abs(ctx.get(dut.o.payload).as_float() - y_expected[n_samples_out]) < 0.005
                     n_samples_out += 1
                     if n_samples_out == len(y_expected):


### PR DESCRIPTION
- Add optimization to `FIR` implementation so you can use the 'stride' argument to avoid performing MACs or needing tap storage for samples that are expected to always be zero.
- Update `Resample` to use this field, meaning it is now a polyphase resampler.
- Add some test cases comparing `Resample` and `FIR` outputs to `scipy.signal` outputs.
- TODO: `n_up` (numerators) must currently be a power of 2, however it should not be so hard to remove this restriction (useful for some common audio ratios e.g 44100 / 48000).