### PR TITLE
midi/polysyn: rewrite MidiVoiceTracker, various improvements

### DIFF
--- a/gateware/src/rs/hal/src/polysynth.rs
+++ b/gateware/src/rs/hal/src/polysynth.rs
@@ -62,9 +62,12 @@ macro_rules! impl_polysynth {
                     self.registers.reso().write(|w| unsafe { w.value().bits(value) } );
                 }
 
-                pub fn set_touch_control(&mut self, value: bool)  {
-                    self.registers.touch_control().write(
-                        |w| unsafe { w.value().bit(value) } );
+                pub fn midi_write(&mut self, value: u32)  {
+                    self.registers.midi_write().write(|w| unsafe { w.msg().bits(value) } );
+                }
+
+                pub fn midi_read(&mut self) -> u32  {
+                    self.registers.midi_read().read().bits()
                 }
             }
         )+

--- a/gateware/src/rs/lib/src/leds.rs
+++ b/gateware/src/rs/lib/src/leds.rs
@@ -2,7 +2,7 @@ use crate::opt::OptionPage;
 
 const PCA9635_BAR_GREEN: [usize; 6] = [0, 2, 14, 12, 6, 4];
 const PCA9635_BAR_RED:   [usize; 6] = [1, 3, 15, 13, 7, 5];
-const _PCA9635_MIDI:     [usize; 2] = [8, 9];
+const PCA9635_MIDI:      [usize; 2] = [8, 9];
 
 pub fn mobo_pca9635_set_bargraph<T: OptionPage>(
     opts: &T, leds: &mut [u8; 16], toggle: bool) {
@@ -33,4 +33,9 @@ pub fn mobo_pca9635_set_bargraph<T: OptionPage>(
             }
         }
     }
+}
+
+pub fn mobo_pca9635_set_midi(leds: &mut [u8; 16], red: u8, green: u8) {
+    leds[PCA9635_MIDI[0]] = green;
+    leds[PCA9635_MIDI[1]] = red;
 }

--- a/gateware/src/tiliqua/midi.py
+++ b/gateware/src/tiliqua/midi.py
@@ -9,8 +9,12 @@ from amaranth              import *
 from amaranth.lib.fifo     import SyncFIFOBuffered
 from amaranth.lib          import wiring, data, enum, stream
 from amaranth.lib.wiring   import In, Out
+from amaranth.lib.memory   import Memory
 
 from amaranth_stdio.serial import AsyncSerialRX
+
+from amaranth_future       import fixed
+from tiliqua.eurorack_pmod import ASQ # hardware native fixed-point sample type
 
 MIDI_BAUD_RATE = 31250
 
@@ -148,69 +152,203 @@ class MidiDecode(wiring.Component):
         return m
 
 class MidiVoice(data.Struct):
-    note:     unsigned(8)
-    velocity: unsigned(8)
+    note:         unsigned(8)
+    velocity:     unsigned(8)
+    gate:         unsigned(1)
+    freq_inc:     ASQ
+    velocity_mod: unsigned(8)
 
 class MidiVoiceTracker(wiring.Component):
 
     """
-    Read a stream of MIDI messages. Decode it into `max_voices` independent
-    streams, one stream per voice, with voice culling. Outgoing streams have
-    'valid' wired to 1, be careful how you synchronize them.
+    Read a stream of MIDI messages. Decode it into :py:`max_voices` independent
+    :py:`MidiVoice` registers, one per voice, with voice culling.
+
+    After each :py:`NOTE_ON` event, a voice is selected, its :py:`MidiVoice.note` is set,
+    the :py:`MidiVoice.gate` attribute is set to 1, and `freq_inc` (linearized
+    frequency used for NCOs) is calculated.
+
+    Pitch bend constantly updates :py:`freq_inc` on all channels. Mod wheel may optionally
+    be used to cap velocity outputs on all channels using :py:`velocity_mod`.
+
+    After each :py:`NOTE_OFF` event, :py:`MidiVoice.gate` is set to 0. If :py:`zero_velocity_gate`
+    is set, the velocity is also set to 0 (instead of the MIDI release velocity).
     """
 
-    def __init__(self, max_voices=8):
+    def __init__(self, max_voices=8, velocity_mod=False, zero_velocity_gate=False):
         self.max_voices = max_voices
+        self.velocity_mod = velocity_mod
+        self.zero_velocity_gate = zero_velocity_gate
         super().__init__({
             "i": In(stream.Signature(MidiMessage)),
-            "o": Out(stream.Signature(MidiVoice)).array(max_voices),
+            "o": Out(MidiVoice).array(max_voices),
         });
 
     def elaborate(self, platform):
         m = Module()
 
-        c_voice = Signal(range(self.max_voices))
-        msg = Signal(MidiMessage)
+        # MIDI note -> linearized frequency LUT memory (exponential converter)
 
-        for n in range(self.max_voices):
-            m.d.comb += self.o[n].valid.eq(1)
+        lut = []
+        sample_rate_hz = 48000
+        for i in range(128):
+            freq = 440 * 2**((i-69)/12.0)
+            freq_inc = freq * (1.0 / sample_rate_hz)
+            lut.append(fixed.Const(freq_inc, shape=ASQ)._value)
+        m.submodules.f_lut_mem = f_lut_mem = Memory(
+                shape=signed(ASQ.as_shape().width), depth=len(lut), init=lut)
+        f_lut_rport = f_lut_mem.read_port()
+        m.d.comb += f_lut_rport.en.eq(1)
+
+        # State captured on each incoming MIDI message
+
+        msg = Signal(MidiMessage)      # last MIDI message
+        last_cc1 = Signal(8, init=255) # last cc1 (mod wheel) position
+        last_pb = Signal(shape=ASQ)    # last pitch bend position
+
+        # write index for NOTE_ON select + commit
+        voice_ix_write = Signal(range(self.max_voices), init=0)
+
+        # voice mask (binary 1 is for an occupied voice slot)
+        voice_mask = Signal(self.max_voices)
+
+        # freq / mod / pb update index
+        ix_update = Signal(range(self.max_voices))
+
+        # FSM to process incoming MIDI messages one at a time and update
+        # internal memories based on these messagse.
 
         with m.FSM() as fsm:
 
             with m.State('WAIT-VALID'):
                 m.d.comb += self.i.ready.eq(1),
                 with m.If(self.i.valid):
+                    m.d.sync += msg.eq(self.i.payload)
                     with m.Switch(self.i.payload.midi_type):
                         with m.Case(MessageType.NOTE_ON):
-                            m.d.sync += msg.eq(self.i.payload)
-                            m.next = 'NOTE-ON'
+                            m.d.sync += voice_ix_write.eq(0)
+                            m.next = 'NOTE-ON-SELECT'
                         with m.Case(MessageType.NOTE_OFF):
-                            m.d.sync += msg.eq(self.i.payload)
                             m.next = 'NOTE-OFF'
+                        with m.Case(MessageType.CONTROL_CHANGE):
+                            m.next = 'CONTROL-CHANGE'
+                        with m.Case(MessageType.PITCH_BEND):
+                            m.next = 'PITCH-BEND'
+                        with m.Case(MessageType.POLY_PRESSURE):
+                            m.next = 'POLY-PRESSURE'
 
-            with m.State('NOTE-ON'):
-                # Simple round robin selection of voice location
-                # TODO: if there is a slot that previously had this note, write
-                # the new velocity there for retriggering.
-                with m.If(c_voice == self.max_voices - 1):
-                    m.d.sync += c_voice.eq(0)
+            with m.State('NOTE-ON-SELECT'):
+                # find an empty note slot to write to
+                # warn: need at least 1 clock for freq LUT RAM output to update
+                # so best not to commit from the same FSM state.
+                with m.If(~voice_mask.bit_select(voice_ix_write, 1)):
+                    m.next = 'NOTE-ON-COMMIT'
                 with m.Else():
-                    m.d.sync += c_voice.eq(c_voice + 1)
-                # Set voice in current location to MIDI payload attributes
-                with m.Switch(c_voice):
+                    m.d.sync += voice_ix_write.eq(voice_ix_write + 1)
+                    with m.If(voice_ix_write == self.max_voices - 1):
+                        # no free note slots
+                        m.next = 'WAIT-VALID'
+
+            with m.State('NOTE-ON-COMMIT'):
+                # commit the new note to the found slot
+                with m.Switch(voice_ix_write):
                     for n in range(self.max_voices):
                         with m.Case(n):
                             m.d.sync += [
-                                self.o[n].payload.note.eq(msg.midi_payload.note_on.note),
-                                self.o[n].payload.velocity.eq(msg.midi_payload.note_on.velocity),
+                                voice_mask.bit_select(n, 1).eq(1),
+                                self.o[n].note.eq(msg.midi_payload.note_on.note),
+                                self.o[n].velocity.eq(msg.midi_payload.note_on.velocity),
+                                self.o[n].gate.eq(1),
                             ]
-                m.next = 'WAIT-VALID'
+                            if not self.velocity_mod:
+                                m.d.sync += self.o[n].velocity_mod.eq(msg.midi_payload.note_on.velocity)
+                m.next = 'UPDATE'
 
             with m.State('NOTE-OFF'):
-                # Cull any voice that matches the MIDI payload note #
+                # cull any voice that matches the MIDI payload note #
                 for n in range(self.max_voices):
-                    with m.If(self.o[n].payload.note == msg.midi_payload.note_on.note):
-                        m.d.sync += self.o[n].payload.velocity.eq(0)
-                m.next = 'WAIT-VALID'
+                    with m.If(self.o[n].note == msg.midi_payload.note_off.note):
+                        m.d.sync += [
+                            voice_mask.bit_select(n, 1).eq(0),
+                            self.o[n].gate.eq(0),
+                        ]
+                        if self.zero_velocity_gate:
+                            m.d.sync += self.o[n].velocity.eq(0)
+                        else:
+                            m.d.sync += self.o[n].velocity.eq(msg.midi_payload.note_off.velocity)
+                m.next = 'UPDATE'
+
+            with m.State('POLY-PRESSURE'):
+                # update any voice that matches the MIDI payload note #
+                # TODO: rather than piggybacking on velocity, this should probably be its own field?
+                for n in range(self.max_voices):
+                    with m.If((self.o[n].note == msg.midi_payload.poly_pressure.note) & self.o[n].gate):
+                        m.d.sync += self.o[n].velocity.eq(msg.midi_payload.poly_pressure.pressure)
+                m.next = 'UPDATE'
+
+            with m.State('CONTROL-CHANGE'):
+                with m.If(msg.midi_payload.control_change.controller_number == 1):
+                    m.d.sync += last_cc1.eq(msg.midi_payload.control_change.data)
+                with m.If(msg.midi_payload.control_change.controller_number == 123):
+                    # all stop
+                    for n in range(self.max_voices):
+                        m.d.sync += self.o[n].gate.eq(0)
+                        if self.zero_velocity_gate:
+                            m.d.sync += self.o[n].velocity.eq(0)
+                m.next = 'UPDATE'
+
+            with m.State('PITCH-BEND'):
+                # convert 14-bit pitch bend to 16-bit signed ASQ -1 .. 1
+                pb = Signal(signed(16))
+                m.d.comb += pb.eq(Cat(msg.midi_payload.pitch_bend.lsb,
+                                      msg.midi_payload.pitch_bend.msb))
+                m.d.sync += last_pb.raw().eq(pb-(2*8192))
+                m.next = 'UPDATE'
+
+            with m.State('UPDATE'):
+                # set LUT not address so we can calculate frequency from it
+                with m.Switch(ix_update):
+                    for n in range(self.max_voices):
+                        with m.Case(n):
+                            m.d.comb += f_lut_rport.addr.eq(self.o[n].note),
+                m.next = 'UPDATE-FREQ-VEL'
+
+            with m.State('UPDATE-FREQ-VEL'):
+
+                # Update linear frequency and velocity based on note values,
+                # pitch bend and (optionally) mod wheel.
+
+                # pitch bend factor
+                pb_factor = fixed.Const(0.1225, shape=ASQ)
+                pb_scaled = Signal(shape=ASQ)
+                m.d.comb += pb_scaled.eq(pb_factor * last_pb)
+
+                # linearized frequency from LUT * pitch bend
+                calculated_freq = Signal(ASQ)
+                f_inc_base = Signal(ASQ)
+                m.d.comb += [
+                    f_inc_base.raw().eq(f_lut_rport.data),
+                    calculated_freq.eq(f_inc_base + f_inc_base*pb_scaled),
+                ]
+
+                # latch to correct output register
+                with m.Switch(ix_update):
+                    for n in range(self.max_voices):
+                        with m.Case(n):
+                            # latch linear frequency + pitch bend
+                            m.d.sync += self.o[n].freq_inc.eq(calculated_freq)
+                            # optional mod wheel caps `velocity_mod` field.
+                            if self.velocity_mod:
+                                with m.If(last_cc1 < self.o[n].velocity):
+                                    m.d.sync += self.o[n].velocity_mod.eq(last_cc1)
+                                with m.Else():
+                                    m.d.sync += self.o[n].velocity_mod.eq(self.o[n].velocity)
+
+                # Check if we've updated every slot.
+                m.d.sync += ix_update.eq(ix_update + 1)
+                with m.If(ix_update == self.max_voices - 1):
+                    m.next = 'WAIT-VALID'
+                with m.Else():
+                    m.next = 'UPDATE'
 
         return m

--- a/gateware/src/top/polysyn/fw/Cargo.lock
+++ b/gateware/src/top/polysyn/fw/Cargo.lock
@@ -164,6 +164,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
+name = "midi-convert"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f4776f9d450d481dc41e3dce9c10b11a9ec5955aca7c13215e94fe9477f2f7"
+dependencies = [
+ "midi-types",
+]
+
+[[package]]
+name = "midi-types"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0bbe5256e5c434947d790788426bb65773502784aed7b23408f7e7fb4d8eb5"
+
+[[package]]
 name = "nb"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +328,8 @@ dependencies = [
  "heapless",
  "log",
  "micromath",
+ "midi-convert",
+ "midi-types",
  "panic-halt",
  "riscv",
  "riscv-rt",

--- a/gateware/src/top/polysyn/fw/Cargo.toml
+++ b/gateware/src/top/polysyn/fw/Cargo.toml
@@ -20,6 +20,8 @@ heapless = "0.8.0"
 strum_macros = "0.26.4"
 strum = {version = "0.25.0", features = ["derive"], default-features=false}
 fixed = "1.28.0"
+midi-types = "0.1.7"
+midi-convert = "0.2.0"
 
 [profile.release]
 codegen-units = 1

--- a/gateware/src/top/polysyn/fw/src/opts.rs
+++ b/gateware/src/top/polysyn/fw/src/opts.rs
@@ -19,15 +19,15 @@ pub enum Screen {
 
 #[derive(Clone, Copy, PartialEq, EnumIter, IntoStaticStr)]
 #[strum(serialize_all = "kebab-case")]
-pub enum ControlInterface {
-    Touch,
-    MidiCV,
+pub enum TouchControl {
+    On,
+    Off,
 }
 
 #[derive(Clone)]
 pub struct PolyOptions {
     pub selected: Option<usize>,
-    pub interface: EnumOption<ControlInterface>,
+    pub interface: EnumOption<TouchControl>,
     pub drive:     NumOption<u16>,
     pub reso:      NumOption<u16>,
     pub diffuse:   NumOption<u16>,
@@ -88,8 +88,8 @@ impl Options {
             poly: PolyOptions {
                 selected: None,
                 interface: EnumOption{
-                    name: String::from_str("control").unwrap(),
-                    value: ControlInterface::Touch,
+                    name: String::from_str("touch").unwrap(),
+                    value: TouchControl::On,
                 },
                 drive: NumOption{
                     name: String::from_str("overdrive").unwrap(),

--- a/gateware/src/top/polysyn/top.py
+++ b/gateware/src/top/polysyn/top.py
@@ -33,6 +33,7 @@ import math
 from amaranth                  import *
 from amaranth.lib              import wiring, data, stream
 from amaranth.lib.wiring       import In, Out, connect, flipped
+from amaranth.lib.fifo         import SyncFIFOBuffered
 
 from amaranth_soc              import csr
 
@@ -89,15 +90,7 @@ class PolySynth(wiring.Component):
     drive: In(unsigned(16))
     reso: In(unsigned(16))
 
-    voice_states: Out(data.StructLayout({
-        "note":  unsigned(8),
-        "cutoff": unsigned(8),
-    })).array(8)
-
-    i_touch_control: In(unsigned(1))
-
-    i_touch: In(8).array(8)
-    i_jack:  In(8)
+    voice_states: Out(midi.MidiVoice).array(8)
 
     def elaborate(self, platform):
         m = Module()
@@ -105,45 +98,18 @@ class PolySynth(wiring.Component):
         # supported simultaneous voices
         n_voices = 8
 
-        # Create LUTs from midi note to freq_inc (ASQ tuning into NCO).
-        # Store it in memories where the address is the midi note,
-        # and the data coming out is directly routed to NCO freq_inc.
-        lut = []
-        sample_rate_hz = 48000
-        for i in range(128):
-            freq = 440 * 2**((i-69)/12.0)
-            freq_inc = freq * (1.0 / sample_rate_hz)
-            lut.append(fixed.Const(freq_inc, shape=ASQ)._value)
-        # TODO: port to lib.memory (for amaranth ~= 0.5)
-        mems = [Memory(width=ASQ.as_shape().width, depth=len(lut), init=lut)
-                for _ in range(n_voices)]
-        rports = [mems[n].read_port(transparent=True) for n in range(n_voices)]
-        dsp.named_submodules(m.submodules, mems)
-
-        m.submodules.voice_tracker = voice_tracker = midi.MidiVoiceTracker(max_voices=n_voices)
-        # 1 smoother per oscillator for filter cutoff, to prevent pops.
-        boxcars = [dsp.Boxcar(n=16) for _ in range(n_voices)]
+        m.submodules.voice_tracker = voice_tracker = midi.MidiVoiceTracker(
+            max_voices=n_voices, velocity_mod=True, zero_velocity_gate=True)
         # 1 oscillator and filter per oscillator
         ncos = [dsp.SawNCO(shift=0) for _ in range(n_voices)]
         svfs = [dsp.SVF() for _ in range(n_voices)]
         m.submodules.merge = merge = dsp.Merge(n_channels=n_voices)
 
-        dsp.named_submodules(m.submodules, boxcars)
         dsp.named_submodules(m.submodules, ncos)
         dsp.named_submodules(m.submodules, svfs)
 
         # Connect MIDI stream -> voice tracker
         wiring.connect(m, wiring.flipped(self.i_midi), voice_tracker.i)
-
-        # Use CC1 (mod wheel) as upper bound on filter cutoff.
-        last_cc1 = Signal(8, reset=255)
-        with m.If(self.i_midi.valid):
-            msg = self.i_midi.payload
-            with m.Switch(msg.midi_type):
-                with m.Case(midi.MessageType.CONTROL_CHANGE):
-                    # mod wheel is CC 1
-                    with m.If(msg.midi_payload.control_change.controller_number == 1):
-                        m.d.sync += last_cc1.eq(msg.midi_payload.control_change.data)
 
         # analog ins
         m.submodules.cv_in = cv_in = dsp.Split(
@@ -152,63 +118,35 @@ class PolySynth(wiring.Component):
 
         for n in range(n_voices):
 
-            m.d.comb += [
-                self.voice_states[n].note.eq(rports[n].addr),
-                self.voice_states[n].cutoff.eq(boxcars[n].i.payload.as_value() >> 3),
-            ]
+            m.d.comb += self.voice_states[n].eq(voice_tracker.o[n])
 
-            with m.If(~self.i_touch_control):
-                # Filter cutoff on all channels is min(mod wheel, note velocity)
-                # Cutoff itself is smoothed by boxcars before being sent to SVF cutoff.
-                with m.If(last_cc1 < voice_tracker.o[n].payload.velocity):
-                    m.d.comb += boxcars[n].i.payload.raw().eq(last_cc1 << 4)
-                with m.Else():
-                    m.d.comb += boxcars[n].i.payload.raw().eq(
-                            voice_tracker.o[n].payload.velocity << 4)
-                # Connect MIDI voice.note -> note to frequency LUT
-                m.d.comb += [
-                    rports[n].en.eq(1),
-                    rports[n].addr.eq(voice_tracker.o[n].payload.note),
-                ]
-            with m.Else():
-                # only first 6 channels touch sensitive
-                if n < 6:
-                    with m.If(self.i_jack[n] == 0):
-                        m.d.comb += boxcars[n].i.payload.raw().eq(self.i_touch[n] << 3)
-                    with m.Else():
-                        m.d.comb += boxcars[n].i.payload.eq(0)
-                # Connect notes from fixed scale for touchsynth
-                touch_note_map = [48, 48+7, 48+12, 48+12+3, 48+12+7, 48+24, 0, 0]
-                m.d.comb += [
-                    rports[n].en.eq(1),
-                    rports[n].addr.eq(touch_note_map[n]),
-                ]
-
-
-            # Connect LUT output -> NCO.i (clocked at i.valid for normal sample rate)
+            # Connect audio in -> NCO.i
             dsp.connect_remap(m, cv_in.o[0], ncos[n].i, lambda o, i : [
                 # For fun, phase mod on audio in #0
                 i.payload.phase   .eq(o.payload),
-                i.payload.freq_inc.eq(rports[n].data) # ok, always valid
+                i.payload.freq_inc.eq(voice_tracker.o[n].freq_inc)
             ])
 
-            # Connect voice.vel and NCO.o -> SVF.i
+            # Simple counting smoother for the filter cutoff.
+            follower = dsp.CountingFollower(bits=8)
+            m.submodules += follower
+            m.d.comb += [
+                follower.i.valid.eq(cv_in.o[0].valid), # hack to clock at audio rate
+                follower.i.payload.eq(voice_tracker.o[n].velocity_mod),
+                follower.o.ready.eq(1)
+            ]
+
+            # Connect voice.vel and NCO.o -> SVF.
             dsp.connect_remap(m, ncos[n].o, svfs[n].i, lambda o, i : [
                 i.payload.x                    .eq(o.payload >> 1),
                 i.payload.resonance.raw()      .eq(self.reso),
-                i.payload.cutoff               .eq(boxcars[n].o.payload) # hack
+                i.payload.cutoff               .eq(follower.o.payload << 5)
             ])
 
             # Connect SVF LPF -> merge channel
             dsp.connect_remap(m, svfs[n].o, merge.i[n], lambda o, i : [
                 i.payload.eq(o.payload.lp),
             ])
-
-            # HACK: Boxcar synchronization
-            m.d.comb += [
-                boxcars[n].i.valid.eq(ncos[n].o.valid),
-                boxcars[n].o.ready.eq(svfs[n].i.ready),
-            ]
 
         # Voice mixdown to stereo. Alternate left/right
         o_channels = 2
@@ -308,8 +246,11 @@ class SynthPeripheral(wiring.Component):
     class MatrixBusy(csr.Register, access="r"):
         busy: csr.Field(csr.action.R, unsigned(1))
 
-    class TouchControl(csr.Register, access="w"):
-        value: csr.Field(csr.action.W, unsigned(1))
+    class MidiWrite(csr.Register, access="w"):
+        msg: csr.Field(csr.action.W, unsigned(32))
+
+    class MidiRead(csr.Register, access="r"):
+        msg: csr.Field(csr.action.R, unsigned(32))
 
     def __init__(self, synth=None):
         self.synth = synth
@@ -320,10 +261,12 @@ class SynthPeripheral(wiring.Component):
                                offset=0x8+i*4) for i in range(8)]
         self._matrix        = regs.add("matrix",        self.Matrix(),       offset=0x28)
         self._matrix_busy   = regs.add("matrix_busy",   self.MatrixBusy(),   offset=0x2C)
-        self._touch_control = regs.add("touch_control", self.TouchControl(), offset=0x30)
+        self._midi_write    = regs.add("midi_write",    self.MidiWrite(),    offset=0x30)
+        self._midi_read     = regs.add("midi_read",     self.MidiRead(),     offset=0x34)
         self._bridge = csr.Bridge(regs.as_memory_map())
         super().__init__({
             "bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
+            "i_midi": In(stream.Signature(midi.MidiMessage))
         })
         self.bus.memory_map = self._bridge.bus.memory_map
 
@@ -337,14 +280,12 @@ class SynthPeripheral(wiring.Component):
             m.d.sync += self.synth.drive.eq(self._drive.f.value.w_data)
         with m.If(self._reso.f.value.w_stb):
             m.d.sync += self.synth.reso.eq(self._reso.f.value.w_data)
-        with m.If(self._touch_control.f.value.w_stb):
-            m.d.sync += self.synth.i_touch_control.eq(self._touch_control.f.value.w_data)
 
         # voice tracking
         for i, voice in enumerate(self._voices):
             m.d.comb += [
                 voice.f.note.r_data  .eq(self.synth.voice_states[i].note),
-                voice.f.cutoff.r_data.eq(self.synth.voice_states[i].cutoff)
+                voice.f.cutoff.r_data.eq(self.synth.voice_states[i].velocity_mod)
             ]
 
         # matrix coefficient update logic
@@ -364,6 +305,34 @@ class SynthPeripheral(wiring.Component):
                 matrix_busy.eq(0),
                 self.synth.diffuser.matrix.c.valid.eq(0),
             ]
+
+
+        # MIDI injection and arbiter between SoC MIDI and HW MIDI -> synth MIDI.
+        m.submodules.soc_midi_fifo = soc_midi_fifo = SyncFIFOBuffered(
+            width=24, depth=8)
+        m.d.comb += [
+            soc_midi_fifo.w_data.eq(self._midi_write.f.msg.w_data),
+            soc_midi_fifo.w_en.eq(self._midi_write.element.w_stb),
+        ]
+        wiring.connect(m, wiring.flipped(self.i_midi), self.synth.i_midi)
+        with m.If(soc_midi_fifo.r_stream.valid):
+            wiring.connect(m, soc_midi_fifo.r_stream, self.synth.i_midi)
+
+        # Pipe TRS MIDI -> SoC read FIFO so SoC can inspect external
+        # MIDI traffic
+        m.submodules.read_midi_fifo = read_midi_fifo = SyncFIFOBuffered(
+            width=24, depth=8)
+        m.d.comb += [
+            read_midi_fifo.w_data.eq(self.i_midi.payload),
+            read_midi_fifo.w_en.eq(self.i_midi.valid & self.i_midi.ready),
+            read_midi_fifo.r_en.eq(self._midi_read.element.r_stb),
+        ]
+
+        with m.If(read_midi_fifo.r_level != 0):
+            m.d.comb += self._midi_read.f.msg.r_data.eq(read_midi_fifo.r_data)
+        with m.Else():
+            m.d.comb += self._midi_read.f.msg.r_data.eq(0)
+
 
         return m
 
@@ -420,11 +389,7 @@ class PolySoc(TiliquaSoc):
                     system_clk_hz=60e6, pins=midi_pins)
             m.submodules.midi_decode = midi_decode = midi.MidiDecode()
             wiring.connect(m, serialrx.o, midi_decode.i)
-            wiring.connect(m, midi_decode.o, polysynth.i_midi)
-
-        # hook up touch + jack
-        m.d.comb += polysynth.i_jack.eq(pmod0.jack)
-        m.d.comb += [polysynth.i_touch[n].eq(pmod0.touch[n]) for n in range(0, 8)]
+            wiring.connect(m, midi_decode.o, self.synth_periph.i_midi)
 
         # polysynth audio
         wiring.connect(m, astream.istream, polysynth.i)

--- a/gateware/tests/test_midi.py
+++ b/gateware/tests/test_midi.py
@@ -39,3 +39,65 @@ class MidiTests(unittest.TestCase):
         sim.add_testbench(testbench)
         with sim.write_vcd(vcd_file=open("test_midi.vcd", "w")):
             sim.run()
+
+    def test_midi_voice_tracker(self):
+
+        dut = midi.MidiVoiceTracker()
+
+        note_range = list(range(40, 48))
+
+        async def stimulus_notes(ctx):
+            """Send some MIDI NOTE_ON events."""
+            for note in note_range:
+                # FIXME: valid before ready in TBs EVERYWHERE!
+                ctx.set(dut.i.valid, 1)
+                ctx.set(dut.i.payload.midi_type, midi.MessageType.NOTE_ON)
+                ctx.set(dut.i.payload.midi_channel, 1)
+                ctx.set(dut.i.payload.midi_payload.note_on.note, note)
+                ctx.set(dut.i.payload.midi_payload.note_on.velocity, 0x60)
+                await ctx.tick().until(dut.i.ready)
+                ctx.set(dut.i.valid, 0)
+                await ctx.tick()
+
+            await ctx.tick().repeat(50)
+
+            for note in note_range:
+                ctx.set(dut.i.valid, 1)
+                ctx.set(dut.i.payload.midi_type, midi.MessageType.NOTE_OFF)
+                ctx.set(dut.i.payload.midi_channel, 1)
+                ctx.set(dut.i.payload.midi_payload.note_off.note, note)
+                ctx.set(dut.i.payload.midi_payload.note_off.velocity, 0x30)
+                await ctx.tick().until(dut.i.ready)
+                ctx.set(dut.i.valid, 0)
+                await ctx.tick()
+
+        async def testbench(ctx):
+            """Check that the NOTE_ON / OFF events correspond to voice slots."""
+            for ticks in range(400):
+                for n in range(dut.max_voices):
+                    note_in_slot = ctx.get(dut.o[n].note)
+                    vel_in_slot  = ctx.get(dut.o[n].velocity)
+                    gate_in_slot = ctx.get(dut.o[n].gate)
+                    print(f"{ticks} slot{n}: note={note_in_slot} vel={vel_in_slot} gate={gate_in_slot}")
+                    if n < len(note_range):
+                        if ticks > 180 and ticks < 200:
+                            # Verify NOTE_ON events written to voice slots.
+                            self.assertEqual(note_in_slot, note_range[n])
+                            self.assertEqual(vel_in_slot,  0x60)
+                            self.assertEqual(gate_in_slot, 1)
+                        if ticks > 380:
+                            # Verify NOTE_OFF events removed from voice slots.
+                            self.assertEqual(note_in_slot, note_range[n])
+                            self.assertEqual(gate_in_slot, 0)
+                            if dut.zero_velocity_gate:
+                                self.assertEqual(vel_in_slot,  0x0)
+                            else:
+                                self.assertEqual(vel_in_slot,  0x30)
+                await ctx.tick()
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_process(stimulus_notes)
+        sim.add_testbench(testbench)
+        with sim.write_vcd(vcd_file=open("test_midi_voice_tracker.vcd", "w")):
+            sim.run()


### PR DESCRIPTION
Rewrite `MidiVoiceTracker` and update `Polysyn` example to use it. Main items:
- TRS MIDI pitch bend + mod wheel now fully supported.
- Much improved voice culling and replacement algorithm.
- Implement MIDI polyphonic pressure messages and all stop (used by touch interface but theoretically controllable through TRS MIDI as well..)
- TRS MIDI input and touch inputs can be used simultaneously (you can touch while pitch bending on a control surface, or play bass notes one the touchjack interface and melody on a keyboard simultaneously etc.)
- Touchjack control messages / notes are routed through the SoC (so we can easily change notes in the menu system in the future, or dynamically based on MIDI inputs)
- Tiliqua TRS MIDI activity LED now actually lights up when there is MIDI traffic.
- Implement more smoothing on touchjack envelopes.