### PR TITLE
usb/host: add basic USB MIDI host implementation and demo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,23 @@ jobs:
           name: example-usb-audio.bit
           path: gateware/build/top.bit
 
+  ubuntu-usb-host:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pdm-project/setup-pdm@v4
+      - uses: YosysHQ/setup-oss-cad-suite@v3
+      - run: git submodule update --init --recursive
+      - run: yosys --version
+      - run: |
+          pdm install
+          pdm usb_host build --midi-device arturia-keylab49-mkii
+        working-directory: gateware
+      - uses: actions/upload-artifact@v4
+        with:
+          name: example-usb-host.bit
+          path: gateware/build/top.bit
+
   ubuntu-bitstream-dsp-nco:
     runs-on: ubuntu-latest
     steps:

--- a/gateware/docs/top.rst
+++ b/gateware/docs/top.rst
@@ -24,6 +24,14 @@ selftest
 usb_audio
 ---------
 
+4-channel USB2 audio interface, based on LUNA project.
+Enumerates as a 4-in, 4-out 48kHz sound card.
+
+usb_host
+---------
+
+.. automodule:: top.usb_host.top
+
 vectorscope_no_soc
 ------------------
 .. automodule:: top.vectorscope_no_soc.top

--- a/gateware/pyproject.toml
+++ b/gateware/pyproject.toml
@@ -36,6 +36,7 @@ vectorscope_no_soc = "src/top/vectorscope_no_soc/top.py"
 bootstub           = "src/top/bootstub/top.py"
 polysyn            = "src/top/polysyn/top.py"
 usb_audio          = "src/top/usb_audio/top.py"
+usb_host           = "src/top/usb_host/top.py"
 xbeam              = "src/top/xbeam/top.py"
 # Additional utilities
 test               = { cmd = "pytest" }

--- a/gateware/src/tiliqua/midi.py
+++ b/gateware/src/tiliqua/midi.py
@@ -375,3 +375,85 @@ class MidiVoiceTracker(wiring.Component):
                     m.next = 'UPDATE'
 
         return m
+
+class MonoMidiCV(wiring.Component):
+
+    """
+    Simple monophonic MIDI stream to CV conversion.
+
+    in (midi stream): midi data for conversion
+    in (audio): not used
+    out0: Gate
+    out1: V/oct CV
+    out2: Velocity
+    out3: Mod Wheel (CC1)
+    """
+
+    i: In(stream.Signature(data.ArrayLayout(ASQ, 4)))
+    o: Out(stream.Signature(data.ArrayLayout(ASQ, 4)))
+
+    # Note: MIDI is valid at a much lower rate than audio streams
+    i_midi: In(stream.Signature(MidiMessage))
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.d.comb += [
+            # Always forward our audio payload
+            self.i.ready.eq(1),
+            self.o.valid.eq(1),
+
+            # Always ready for MIDI messages
+            self.i_midi.ready.eq(1),
+        ]
+
+        # Create a LUT from midi note to voltage (output ASQ).
+        lut = []
+        for i in range(128):
+            volts_per_note = 1.0/12.0
+            volts = i*volts_per_note - 5
+            # convert volts to audio sample
+            x = volts/(2**15/4000)
+            lut.append(fixed.Const(x, shape=ASQ)._value)
+
+        # Store it in a memory where the address is the midi note,
+        # and the data coming out is directly routed to V/Oct out.
+        m.submodules.mem = mem = Memory(
+            shape=signed(ASQ.as_shape().width), depth=len(lut), init=lut)
+        rport = mem.read_port()
+        m.d.comb += [
+            rport.en.eq(1),
+        ]
+
+        # Route memory straight out to our note payload.
+        m.d.sync += self.o.payload[1].as_value().eq(rport.data),
+
+        with m.If(self.i_midi.valid):
+            msg = self.i_midi.payload
+            with m.Switch(msg.midi_type):
+                with m.Case(MessageType.NOTE_ON):
+                    m.d.sync += [
+                        # Gate output on
+                        self.o.payload[0].eq(fixed.Const(0.5, shape=ASQ)),
+                        # Set velocity output
+                        self.o.payload[2].as_value().eq(
+                            msg.midi_payload.note_on.velocity << 8),
+                        # Set note index in LUT
+                        rport.addr.eq(msg.midi_payload.note_on.note),
+                    ]
+                with m.Case(MessageType.NOTE_OFF):
+                    # Zero gate and velocity on NOTE_OFF
+                    m.d.sync += [
+                        self.o.payload[0].eq(0),
+                        self.o.payload[2].eq(0),
+                    ]
+                with m.Case(MessageType.CONTROL_CHANGE):
+                    # mod wheel is CC 1
+                    with m.If(msg.midi_payload.control_change.controller_number == 1):
+                        m.d.sync += [
+                            self.o.payload[3].as_value().eq(
+                                msg.midi_payload.control_change.data << 8),
+                        ]
+
+        return m
+

--- a/gateware/src/tiliqua/usb_host.py
+++ b/gateware/src/tiliqua/usb_host.py
@@ -16,10 +16,10 @@ from luna.gateware.interface.utmi  import *
 from luna.gateware.usb.usb2.packet import *
 
 class TokenPID(enum.Enum, shape=unsigned(4)):
-    OUT   = USBPacketID.OUT
-    IN    = USBPacketID.IN
-    SOF   = USBPacketID.SOF
-    SETUP = USBPacketID.SETUP
+    OUT   = int(USBPacketID.OUT)
+    IN    = int(USBPacketID.IN)
+    SOF   = int(USBPacketID.SOF)
+    SETUP = int(USBPacketID.SETUP)
 
 class TokenPayload(data.Struct):
     # Lightweight storage for token contents,

--- a/gateware/src/tiliqua/usb_host.py
+++ b/gateware/src/tiliqua/usb_host.py
@@ -1,0 +1,631 @@
+# Copyright (c) 2024 S. Holzapfel, apfelaudio UG <info@apfelaudio.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Extremely bare-bones USB host logic intended for using Tiliqua as a USB MIDI host.
+Consider this EXPERIMENTAL. Error handling / retries are not finished.
+"""
+
+from amaranth                      import *
+from amaranth.lib                  import data, enum, wiring, stream
+from amaranth.lib.wiring           import In, Out
+
+from luna.usb2                     import USBDevice
+from luna.gateware.interface.ulpi  import *
+from luna.gateware.interface.utmi  import *
+from luna.gateware.usb.usb2.packet import *
+
+class TokenPID(enum.Enum, shape=unsigned(4)):
+    OUT   = USBPacketID.OUT
+    IN    = USBPacketID.IN
+    SOF   = USBPacketID.SOF
+    SETUP = USBPacketID.SETUP
+
+class TokenPayload(data.Struct):
+    # Lightweight storage for token contents,
+    # excluding crc5 and pid nibble that are
+    # added before this is sent on the wire.
+    pid:  TokenPID
+    data: data.StructLayout({
+        "addr": unsigned(7),
+        "endp": unsigned(4),
+    })
+
+class SetupPayload(data.Struct):
+
+    class Recipient(enum.Enum, shape=unsigned(5)):
+        DEVICE    = 0
+        INTERFACE = 1
+        ENDPOINT  = 2
+        OTHER     = 3
+
+    class Type(enum.Enum, shape=unsigned(2)):
+        STANDARD  = 0
+        CLASS     = 1
+        ENDPOINT  = 2
+        RESERVED  = 3
+
+    class Direction(enum.Enum, shape=unsigned(1)):
+        HOST_TO_DEVICE = 0
+        DEVICE_TO_HOST = 1
+
+    class StandardRequest(enum.Enum, shape=unsigned(8)):
+        SET_ADDRESS       = 0x05
+        GET_DESCRIPTOR    = 0x06
+        SET_CONFIGURATION = 0x09
+
+    bmRequestType: data.StructLayout({
+        'bmRecipient': Recipient,
+        'bmType':      Type,
+        'bmDirection': Direction,
+    })
+    bRequest:      StandardRequest
+    wValue:        unsigned(16)
+    wIndex:        unsigned(16)
+    wLength:       unsigned(16)
+
+    #
+    # Some helpers to quickly create standard request types.
+    # These can be passed directly to the `init` field of signals
+    # of shape SetupPayload.
+    #
+
+    def init_get_descriptor(value, length):
+        return {
+            'bmRequestType': {
+                'bmRecipient': SetupPayload.Recipient.DEVICE,
+                'bmType':      SetupPayload.Type.STANDARD,
+                'bmDirection': SetupPayload.Direction.DEVICE_TO_HOST,
+            },
+            'bRequest': SetupPayload.StandardRequest.GET_DESCRIPTOR,
+            'wValue':   value,
+            'wIndex':   0x0000,
+            'wLength':  length,
+        }
+
+    def init_set_address(address):
+        return {
+            'bmRequestType': {
+                'bmRecipient': SetupPayload.Recipient.DEVICE,
+                'bmType':      SetupPayload.Type.STANDARD,
+                'bmDirection': SetupPayload.Direction.HOST_TO_DEVICE,
+            },
+            'bRequest': SetupPayload.StandardRequest.SET_ADDRESS,
+            'wValue':   address,
+            'wIndex':   0x0000,
+            'wLength':  0x0000,
+        }
+
+
+    def init_set_configuration(configuration):
+        return {
+            'bmRequestType': {
+                'bmRecipient': SetupPayload.Recipient.DEVICE,
+                'bmType':      SetupPayload.Type.STANDARD,
+                'bmDirection': SetupPayload.Direction.HOST_TO_DEVICE,
+            },
+            'bRequest': SetupPayload.StandardRequest.SET_CONFIGURATION,
+            'wValue':   configuration,
+            'wIndex':   0x0000,
+            'wLength':  0x0000,
+        }
+
+
+class USBTokenPacketGenerator(wiring.Component):
+
+    """
+    Send a stream of TokenPayloads over UTMI.
+
+    A TokenPayload requires a second PID nibble and crc5 for it to
+    be ready for the wire (UTMI). This is calculated here.
+    """
+
+    #
+    # IN tokens use InterPacketTimer to determine when `txa`
+    # (Tx Allowed) is permitted, other tokens need more time.
+    # This is that time in cycles.
+    #
+    _LONG_TXA_POST_TRANSMIT = 200
+
+    def __init__(self):
+        self.tx = UTMITransmitInterface()
+        self.timer = InterpacketTimerInterface()
+        super().__init__({
+            "i": In(stream.Signature(TokenPayload)),
+            "txa": Out(1),
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        pkt = Signal(shape=TokenPayload)
+
+        with m.FSM(domain="usb"):
+
+            with m.State('IDLE'):
+                m.d.comb += self.i.ready.eq(1)
+                with m.If(self.i.valid):
+                    m.d.usb += pkt.eq(self.i.payload)
+                    m.next = "SEND_PID"
+
+            with m.State('SEND_PID'):
+
+                with m.Switch(pkt.pid):
+                    with m.Case(TokenPID.OUT):
+                        m.d.comb += self.tx.data.eq(USBPacketID.OUT.byte()),
+                    with m.Case(TokenPID.IN):
+                        m.d.comb += self.tx.data.eq(USBPacketID.IN.byte()),
+                    with m.Case(TokenPID.SOF):
+                        m.d.comb += self.tx.data.eq(USBPacketID.SOF.byte()),
+                    with m.Case(TokenPID.SETUP):
+                        m.d.comb += self.tx.data.eq(USBPacketID.SETUP.byte()),
+
+                m.d.comb += self.tx.valid.eq(1),
+
+                with m.If(self.tx.ready):
+                    m.next = 'SEND_PAYLOAD0'
+
+            with m.State('SEND_PAYLOAD0'):
+                m.d.comb += [
+                    self.tx.data .eq(pkt.data.as_value()[0:8]),
+                    self.tx.valid.eq(1),
+                ]
+                with m.If(self.tx.ready):
+                    m.next = 'SEND_PAYLOAD1'
+
+            with m.State('SEND_PAYLOAD1'):
+                crc5 = Signal(5)
+                m.d.comb += [
+                    crc5.eq(USBTokenDetector.generate_crc_for_token(pkt.data.as_value())),
+                    self.tx.data .eq(Cat(pkt.data.as_value()[8:11], crc5)),
+                    self.tx.valid.eq(1),
+                ]
+                with m.If(self.tx.ready):
+                    m.d.comb += self.timer.start.eq(1)
+                    with m.If(pkt.pid == TokenPID.IN):
+                        m.d.comb += self.txa.eq(1)
+                        m.next = 'WAIT-SHORT-TXA'
+                    with m.Else():
+                        m.next = 'WAIT-LONG-TXA'
+
+            with m.State('WAIT-SHORT-TXA'):
+                with m.If(self.timer.tx_allowed):
+                    m.next = 'IDLE'
+
+            with m.State('WAIT-LONG-TXA'):
+                cnt = Signal(range(self._LONG_TXA_POST_TRANSMIT))
+                m.d.usb += cnt.eq(cnt+1)
+                with m.If(cnt == (self._LONG_TXA_POST_TRANSMIT - 1)):
+                    m.d.comb += self.txa.eq(1)
+                    m.d.usb += cnt.eq(0)
+                    m.next = 'IDLE'
+
+        return m
+
+class USBSOFController(wiring.Component):
+
+    """
+    If :py:`enable == 1`, emit a single SOF TokenPayload every 1ms.
+
+    :py:`txa` is strobed when transmissions are allowed after a SOF is sent.
+
+    TODO: microframes for HS links.
+    """
+
+    enable: In(1)
+    txa:    Out(1)
+    o: Out(stream.Signature(TokenPayload))
+
+    # FS: emit a SOF packet every 1ms
+    _SOF_CYCLES = 60000
+
+    # FS: delay from SOF packet being enqueued and this controller
+    # strobing `txa` to indicate the next packet may be sent.
+    # TODO: reduce this number? 0.7msec just taken from traces.
+    _SOF_TX_TO_TX_MIN = 7*6000
+
+    def elaborate(self, platform):
+        m = Module()
+
+        sof_timer = Signal(16)
+        frame_number = Signal(11, reset=0)
+
+        m.d.usb +=  sof_timer.eq(sof_timer + 1),
+
+        m.d.comb += [
+            self.o.payload.pid.eq(TokenPID.SOF),
+            self.o.payload.data.eq(frame_number),
+        ]
+
+        with m.FSM(domain="usb"):
+
+            with m.State('OFF'):
+                m.d.usb += [
+                    sof_timer.eq(0),
+                    frame_number.eq(0),
+                ]
+                with m.If(self.enable):
+                    m.next = 'IDLE'
+
+            with m.State('IDLE'):
+                with m.If(sof_timer == (self._SOF_CYCLES - 1)):
+                    m.d.usb += sof_timer.eq(0)
+                    m.d.usb += frame_number.eq(frame_number + 1)
+                    m.next = 'SEND'
+                with m.If(~self.enable):
+                    m.next = 'OFF'
+
+            with m.State('SEND'):
+                m.d.comb += self.o.valid.eq(1)
+                with m.If(self.o.ready):
+                    m.next = 'WAIT-TX-ALLOWED'
+
+            with m.State('WAIT-TX-ALLOWED'):
+                cnt = Signal(range(self._SOF_TX_TO_TX_MIN))
+                m.d.usb += cnt.eq(cnt+1)
+                with m.If(cnt == (self._SOF_TX_TO_TX_MIN - 1)):
+                    m.d.comb += self.txa.eq(1)
+                    m.d.usb += cnt.eq(0)
+                    m.next = 'IDLE'
+
+        return m
+
+
+class SimpleUSBMIDIHost(Elaboratable):
+
+    """
+    Extremely bare-bones USB MIDI host that uses an ULPI PHY interface.
+    For now, full-speed only (most MIDI devices are).
+
+    This does the bare minimum to enumerate a device, set the correct configuration
+    and poll it for MIDI information on a BULK IN endpoint.
+
+    Proper error handling and retries are not complete yet. This controller
+    currently walks the happy path of a few MIDI devices I have fine, however
+    still requires extensive testing.
+
+    The USB configuration ID and MIDI endpoint are currently hard-coded, that is,
+    the descriptors themselves are not inspected to find the correct interface,
+    and you must provide them before elaboration.
+
+    This should not be so hard to add. Goal of this core initially is just
+    to verify the Tiliqua hardware design can function as a USB host.
+    """
+
+    # Address that is assigned to the connected device during the SETUP phase.
+    # The host is free to choose whatever it wants for this.
+    _DEFAULT_DEVICE_ADDR = 0x12
+
+    def __init__(self, *, bus=None, handle_clocking=True, sim=False,
+                 hardcoded_configuration_id=0x0001,
+                 hardcoded_midi_endpoint=1):
+        # FIXME: for now, the configuration and endpoint ID for the MIDI interface is hardcoded.
+        self.configuration_id = hardcoded_configuration_id
+        self.midi_endpoint_id = hardcoded_midi_endpoint
+        self.sim = sim
+        if self.sim:
+            self.utmi = UTMIInterface()
+        else:
+            self.utmi = UTMITranslator(ulpi=bus, handle_clocking=handle_clocking)
+            self.translator = self.utmi
+        self.receiver   = USBDataPacketReceiver(utmi=self.utmi)
+        self.handshake_detector  = USBHandshakeDetector(utmi=self.utmi)
+
+    def elaborate(self, platform):
+
+        m = Module()
+
+        if not self.sim:
+            m.submodules.translator = self.translator
+        m.submodules.transmitter         = transmitter = USBDataPacketGenerator()
+        m.submodules.receiver            = receiver = self.receiver
+        m.submodules.data_crc            = data_crc = USBDataPacketCRC()
+        m.submodules.handshake_generator = handshake_generator = USBHandshakeGenerator()
+        m.submodules.handshake_detector  = handshake_detector = self.handshake_detector
+        m.submodules.token_generator     = token_generator = USBTokenPacketGenerator()
+        m.submodules.sof_controller      = sof_controller = USBSOFController()
+        m.submodules.timer               = timer = \
+            USBInterpacketTimer(fs_only  = True)
+        m.submodules.tx_multiplexer      = tx_multiplexer = UTMIInterfaceMultiplexer()
+
+        # Data CRC interfaces
+        data_crc.add_interface(transmitter.crc)
+        data_crc.add_interface(receiver.data_crc)
+
+        # Inter-packet timer interfaces.
+        timer.add_interface(receiver.timer)
+        timer.add_interface(token_generator.timer)
+
+        # UTMI transmission interfaces
+        tx_multiplexer.add_input(token_generator.tx)
+        tx_multiplexer.add_input(transmitter.tx)
+        tx_multiplexer.add_input(handshake_generator.tx)
+
+        # Unless a particular state below is sending tokens, token
+        # generator is always hooked up to the SOF generator.
+        wiring.connect(m, sof_controller.o, token_generator.i)
+
+        m.d.comb += [
+            # Enable host pulldowns
+            self.utmi.dm_pulldown.eq(1),
+            self.utmi.dp_pulldown.eq(1),
+
+            # By default, put transceiver in normal FS mode
+            # (non-driving unless we actively send packets)
+            self.utmi.op_mode.eq(UTMIOperatingMode.NORMAL),
+            self.utmi.xcvr_select.eq(USBSpeed.FULL),
+            self.utmi.term_select.eq(UTMITerminationSelect.LS_FS_NORMAL),
+
+            # Wire up respective LUNA components
+            timer.speed.eq(USBSpeed.FULL),
+            tx_multiplexer.output .attach(self.utmi),
+            data_crc.tx_valid     .eq(tx_multiplexer.output.valid & self.utmi.tx_ready),
+            data_crc.tx_data      .eq(tx_multiplexer.output.data),
+            data_crc.rx_data      .eq(self.utmi.rx_data),
+            data_crc.rx_valid     .eq(self.utmi.rx_valid),
+
+            # Enable SOF transmission by default.
+            sof_controller.enable.eq(1),
+        ]
+
+        midi_toggle = Signal()
+        if not self.sim:
+            m.d.comb += platform.request("led_a").o.eq(midi_toggle)
+
+        _CONNECT_UNTIL_RESET_CYCLES = 13*600000 # 130ms
+        _BUS_RESET_HOLD_CYCLES      = 6*600000  # 60ms
+        _SOF_COUNTER_MAX            = 1024
+
+        # Index after every SOF_COUNTER_MAX rolls over at which
+        # to attempt a setup request to enter BULK_IN poll mode.
+        if self.sim:
+            _SETUP_ON_SOF_INDEX     = 1
+        else:
+            _SETUP_ON_SOF_INDEX     = 65
+
+        with m.FSM(domain="usb"):
+
+            #
+            # HELPERS FOR CONSTRUCTING FSM STATES
+            #
+
+            def fsm_tx_token(state_id, pid, addr, endp, next_state_id):
+                """
+                Single FSM state that emits a token packet
+                with the provided payload and does not move to
+                the next state until transmissions are allowed again.
+                """
+                with m.State(state_id):
+                    enqueued = Signal()
+                    m.d.comb += [
+                        token_generator.i.valid.eq(1),
+                        token_generator.i.payload.pid.eq(pid),
+                        token_generator.i.payload.data.addr.eq(addr),
+                        token_generator.i.payload.data.endp.eq(endp),
+                    ]
+                    with m.If(token_generator.i.ready):
+                        m.d.usb += enqueued.eq(1)
+                    with m.If(enqueued & token_generator.txa):
+                        m.d.usb += enqueued.eq(0)
+                        m.next = next_state_id
+
+            def fsm_tx_data_stage(state_id, data_shape, data_pid, data_payload, next_state_id):
+                """
+                Single FSM state that emits a DATA0/DATA1 packet. and does not move
+                to the next state until the packet is enqueued for transmission.
+                """
+                with m.State(state_id):
+                    data_length = data_shape.as_shape().size // 8
+                    payload = Const(data_payload, shape=data_shape)
+                    data_view = Signal(data.ArrayLayout(unsigned(8), data_length))
+                    ix = Signal(range(data_length))
+                    m.d.comb += [
+                        data_view.eq(payload),
+                        transmitter.data_pid.eq(data_pid), # DATA0/DATA1 etc
+                        transmitter.stream.valid.eq(1),
+                        transmitter.stream.payload.eq(data_view[ix]),
+                    ]
+                    with m.If(ix == 0):
+                        m.d.comb += transmitter.stream.first.eq(1)
+                    with m.If(ix == len(data_view) - 1):
+                        m.d.comb += transmitter.stream.last.eq(1)
+                    with m.If(transmitter.stream.ready):
+                        m.d.usb += ix.eq(ix+1)
+                        with m.If(ix == len(data_view) - 1):
+                            m.next = next_state_id
+
+            def fsm_sequence_zlp_out(state_id, next_state_id, data_pid=1):
+                """
+                Wait for next SOF, emit an OUT token followed by ZLP and check it is acknowledged.
+                """
+                with m.State(state_id):
+                    with m.If(sof_controller.txa):
+                        m.next = f'{state_id}-TOKEN'
+
+                fsm_tx_token(f'{state_id}-TOKEN', TokenPID.OUT, 0, 0, f'{state_id}-TX-ZLP')
+
+                with m.State(f'{state_id}-TX-ZLP'):
+                    m.d.comb += [
+                        transmitter.data_pid.eq(data_pid),
+                        transmitter.stream.last.eq(1),
+                        transmitter.stream.valid.eq(1),
+                    ]
+                    # FIXME: cannot gate on transmitter.stream.ready because
+                    # ZLP never strobes that signal! need another way..
+                    m.next = f'{state_id}-WAIT-ACK'
+
+                with m.State(f'{state_id}-WAIT-ACK'):
+                    # FIXME: detect ZLP ACK failure
+                    with m.If(handshake_detector.detected.ack):
+                        m.next = next_state_id
+
+            def fsm_sequence_rx_in_stage_ignore(state_id, state_ok, state_err, addr=0, endp=0):
+                """
+                Wait for next SOF.
+                Emit an IN token, verify we got data and acknowledge it.
+                The data itself is simply ignored for now.
+                """
+
+                with m.State(state_id):
+                    with m.If(sof_controller.txa):
+                        m.next = f'{state_id}-TOKEN'
+
+                fsm_tx_token(f'{state_id}-TOKEN', TokenPID.IN, addr, endp, f'{state_id}-WAIT-PKT')
+
+                with m.State(f'{state_id}-WAIT-PKT'):
+                    # FIXME: tolerate rx timeout
+                    with m.If(receiver.packet_complete):
+                        m.next = f'{state_id}-ACK-PKT'
+                    with m.If(handshake_detector.detected.nak):
+                        m.next = state_err
+
+                with m.State(f'{state_id}-ACK-PKT'):
+                    with m.If(receiver.ready_for_response):
+                        m.d.comb += handshake_generator.issue_ack.eq(1)
+                        m.next = state_ok
+
+            def fsm_sequence_setup(state_id, state_ok, state_err, setup_payload, addr=0, endp=0):
+                """
+                Wait for next SOF.
+                Emit a SETUP token, followed by a DATA0 payload and check it is acknowledged.
+                """
+                with m.State(state_id):
+                    with m.If(sof_controller.txa):
+                        m.next = f'{state_id}-TOKEN'
+
+                fsm_tx_token(f'{state_id}-TOKEN', TokenPID.SETUP, addr, endp, f'{state_id}-DATA0')
+
+                fsm_tx_data_stage(f'{state_id}-DATA0',
+                                  data_shape=SetupPayload,
+                                  data_pid=0, # DATA0
+                                  data_payload=setup_payload,
+                                  next_state_id=f'{state_id}-WAIT-ACK')
+
+                with m.State(f'{state_id}-WAIT-ACK'):
+                    with m.If(handshake_detector.detected.ack):
+                        m.next = state_ok
+                    with m.If(token_generator.timer.rx_timeout |
+                              handshake_detector.detected.nak):
+                        m.next = state_err
+
+            if not self.sim:
+
+                #
+                # BUS RESET LOGIC
+                #
+
+                # TODO: move bus reset logic to dedicated component
+
+                # Wait for an FS device to be connected
+                # If it remains connected for 130ms, issue a bus reset.
+                with m.State('IDLE'):
+                    _LINE_STATE_FS_HS_J = 0b01
+                    # Do not drive bus. Disable SOF transmission
+                    m.d.comb += sof_controller.enable.eq(0),
+                    connected_for_cycles = Signal(32)
+                    with m.If(self.utmi.line_state == _LINE_STATE_FS_HS_J):
+                        m.d.usb += connected_for_cycles.eq(connected_for_cycles+1)
+                    with m.Else():
+                        m.d.usb += connected_for_cycles.eq(0)
+                    with m.If(connected_for_cycles == _CONNECT_UNTIL_RESET_CYCLES):
+                        m.next = 'BUS-RESET'
+
+                # Bus reset: issue an SE0 for 60ms
+                with m.State('BUS-RESET'):
+                    # Drive SE0 on bus. Disable SOF transmission
+                    m.d.comb += [
+                        sof_controller.enable.eq(0),
+                        self.utmi.op_mode.eq(UTMIOperatingMode.RAW_DRIVE),
+                        self.utmi.xcvr_select.eq(USBSpeed.HIGH),
+                        self.utmi.term_select.eq(UTMITerminationSelect.HS_NORMAL),
+                    ]
+                    se0_cycles = Signal(64)
+                    m.d.usb += se0_cycles.eq(se0_cycles+1)
+                    with m.If(se0_cycles == _BUS_RESET_HOLD_CYCLES):
+                        m.d.usb += se0_cycles.eq(0)
+                        m.next = 'SOF-IDLE'
+
+            #
+            # HOST PACKET STATE MACHINE
+            #
+
+            #
+            # SOF IDLE LOOP
+            #
+            # Send SOFs, and once every N SOFs, try the setup sequence.
+            #
+
+            with m.State('SOF-IDLE'):
+                sof_counter = Signal(range(_SOF_COUNTER_MAX))
+                with m.If(sof_controller.txa):
+                    m.d.usb += sof_counter.eq(sof_counter+1)
+                    with m.If(sof_counter == (_SOF_COUNTER_MAX-1)):
+                        m.d.usb += sof_counter.eq(0)
+                    with m.If(sof_counter == _SETUP_ON_SOF_INDEX):
+                        m.next = 'SETUP0'
+
+            #
+            # SETUP0: GET_DESCRIPTOR
+            #
+
+            fsm_sequence_setup('SETUP0',
+                               state_ok='SETUP0-IN',
+                               state_err='SOF-IDLE',
+                               setup_payload=SetupPayload.init_get_descriptor(0x0100, 0x0040),
+                               addr=0,
+                               endp=0)
+
+            fsm_sequence_rx_in_stage_ignore('SETUP0-IN', state_ok='SETUP0-ZLP-OUT', state_err='SETUP0-IN')
+
+            fsm_sequence_zlp_out('SETUP0-ZLP-OUT', 'SETUP1')
+
+            #
+            # SETUP1: SET_ADDRESS
+            #
+
+            fsm_sequence_setup('SETUP1',
+                               state_ok='SETUP1-IN',
+                               state_err='SOF-IDLE',
+                               setup_payload=SetupPayload.init_set_address(self._DEFAULT_DEVICE_ADDR),
+                               addr=0,
+                               endp=0)
+
+            fsm_sequence_rx_in_stage_ignore('SETUP1-IN', state_ok='SETUP2', state_err='SETUP1-IN')
+
+            #
+            # SETUP2: SET_CONFIGURATION
+            #
+
+            # NOTE: device address is now set! Token addr must always be set to match.
+
+            fsm_sequence_setup('SETUP2',
+                               state_ok='SETUP2-IN',
+                               state_err='SOF-IDLE',
+                               setup_payload=SetupPayload.init_set_configuration(self.configuration_id),
+                               addr=self._DEFAULT_DEVICE_ADDR,
+                               endp=0)
+
+            fsm_sequence_rx_in_stage_ignore('SETUP2-IN', state_ok='MIDI-IDLE-SOF',
+                                            state_err='SETUP2-IN', addr=self._DEFAULT_DEVICE_ADDR)
+
+            #
+            # MIDI BULK IN (continuous polling)
+            #
+
+            with m.State('MIDI-IDLE-SOF'):
+                with m.If(sof_controller.txa):
+                    m.next = 'BULK-IN-TOKEN'
+
+            fsm_tx_token('BULK-IN-TOKEN', TokenPID.IN, self._DEFAULT_DEVICE_ADDR,
+                         self.midi_endpoint_id, 'MIDI-BULK-IN')
+
+            with m.State('MIDI-BULK-IN'):
+                with m.If(receiver.ready_for_response):
+                    m.d.comb += handshake_generator.issue_ack.eq(1)
+                    m.d.usb += midi_toggle.eq(~midi_toggle)
+                    m.next = 'MIDI-IDLE-SOF'
+                with m.If(handshake_detector.detected.nak):
+                    m.next = 'MIDI-IDLE-SOF'
+
+        return m
+

--- a/gateware/src/top/dsp/top.py
+++ b/gateware/src/top/dsp/top.py
@@ -465,86 +465,6 @@ class TouchMixTop(wiring.Component):
 
         return m
 
-class MidiCVTop(wiring.Component):
-
-    """
-    Simple monophonic MIDI to CV conversion.
-
-    in: (TRS MIDI)
-    out0: Gate
-    out1: V/oct CV
-    out2: Velocity
-    out3: Mod Wheel (CC1)
-    """
-
-    i: In(stream.Signature(data.ArrayLayout(ASQ, 4)))
-    o: Out(stream.Signature(data.ArrayLayout(ASQ, 4)))
-
-    # Note: MIDI is valid at a much lower rate than audio streams
-    i_midi: In(stream.Signature(midi.MidiMessage))
-
-    def elaborate(self, platform):
-        m = Module()
-
-        m.d.comb += [
-            # Always forward our audio payload
-            self.i.ready.eq(1),
-            self.o.valid.eq(1),
-
-            # Always ready for MIDI messages
-            self.i_midi.ready.eq(1),
-        ]
-
-        # Create a LUT from midi note to voltage (output ASQ).
-        lut = []
-        for i in range(128):
-            volts_per_note = 1.0/12.0
-            volts = i*volts_per_note - 5
-            # convert volts to audio sample
-            x = volts/(2**15/4000)
-            lut.append(fixed.Const(x, shape=ASQ)._value)
-
-        # Store it in a memory where the address is the midi note,
-        # and the data coming out is directly routed to V/Oct out.
-        m.submodules.mem = mem = Memory(
-            width=ASQ.as_shape().width, depth=len(lut), init=lut)
-        rport = mem.read_port(transparent=True)
-        m.d.comb += [
-            rport.en.eq(1),
-        ]
-
-        # Route memory straight out to our note payload.
-        m.d.sync += self.o.payload[1].as_value().eq(rport.data),
-
-        with m.If(self.i_midi.valid):
-            msg = self.i_midi.payload
-            with m.Switch(msg.midi_type):
-                with m.Case(midi.MessageType.NOTE_ON):
-                    m.d.sync += [
-                        # Gate output on
-                        self.o.payload[0].eq(fixed.Const(0.5, shape=ASQ)),
-                        # Set velocity output
-                        self.o.payload[2].as_value().eq(
-                            msg.midi_payload.note_on.velocity << 8),
-                        # Set note index in LUT
-                        rport.addr.eq(msg.midi_payload.note_on.note),
-                    ]
-                with m.Case(midi.MessageType.NOTE_OFF):
-                    # Zero gate and velocity on NOTE_OFF
-                    m.d.sync += [
-                        self.o.payload[0].eq(0),
-                        self.o.payload[2].eq(0),
-                    ]
-                with m.Case(midi.MessageType.CONTROL_CHANGE):
-                    # mod wheel is CC 1
-                    with m.If(msg.midi_payload.control_change.controller_number == 1):
-                        m.d.sync += [
-                            self.o.payload[3].as_value().eq(
-                                msg.midi_payload.control_change.data << 8),
-                        ]
-
-        return m
-
 class PSRAMPingPongDelay(wiring.Component):
 
     """
@@ -940,7 +860,7 @@ CORES = {
     "matrix":         (False, Matrix),
     "touchmix":       (True,  TouchMixTop),
     "waveshaper":     (False, DualWaveshaper),
-    "midicv":         (False, MidiCVTop),
+    "midicv":         (False, midi.MonoMidiCV),
     "psram_pingpong": (False, PSRAMPingPongDelay),
     "sram_pingpong":  (False, SRAMPingPongDelay),
     "psram_diffuser": (False, PSRAMDiffuser),

--- a/gateware/src/top/usb_host/top.py
+++ b/gateware/src/top/usb_host/top.py
@@ -9,8 +9,8 @@ Extremely bare-bones USB MIDI host demo. EXPERIMENTAL.
 At the moment this is only used for Tiliqua hardware validation.
 NOTE: the MIDI USB configuration and endpoint IDs are hard-coded below.
 
-At the moment, all the MIDI traffic does is blink an LED.
-A better demo would run a MIDI/CV conversion as we do for TRS MIDI.
+At the moment, all the MIDI traffic is routed to CV outputs according
+to the existing example (see docstring) in `top/dsp:MidiCVTop`.
 """
 
 
@@ -143,7 +143,7 @@ class USB2HostTest(Elaboratable):
         )
 
 
-        m.submodules.midi_decode = midi_decode = midi.MidiDecode()
+        m.submodules.midi_decode = midi_decode = midi.MidiDecode(usb=True)
         wiring.connect(m, usb.o_midi_bytes, midi_decode.i)
 
         m.submodules.pmod0 = pmod0 = eurorack_pmod.EurorackPmod(

--- a/gateware/src/top/usb_host/top.py
+++ b/gateware/src/top/usb_host/top.py
@@ -18,10 +18,94 @@ from amaranth                     import *
 from amaranth.build               import *
 from amaranth.lib.cdc             import FFSynchronizer
 
+from amaranth_future              import fixed
+
+from tiliqua.eurorack_pmod        import ASQ
+from tiliqua                      import midi, eurorack_pmod
 from tiliqua.usb_host             import *
 from tiliqua.cli                  import top_level_cli
 from tiliqua.tiliqua_platform     import RebootProvider
 from vendor.ila                   import AsyncSerialILA
+
+class MidiCVTop(wiring.Component):
+
+    """
+    Simple monophonic MIDI to CV conversion.
+
+    in: (TRS MIDI)
+    out0: Gate
+    out1: V/oct CV
+    out2: Velocity
+    out3: Mod Wheel (CC1)
+    """
+
+    i: In(stream.Signature(data.ArrayLayout(ASQ, 4)))
+    o: Out(stream.Signature(data.ArrayLayout(ASQ, 4)))
+
+    # Note: MIDI is valid at a much lower rate than audio streams
+    i_midi: In(stream.Signature(midi.MidiMessage))
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.d.comb += [
+            # Always forward our audio payload
+            self.i.ready.eq(1),
+            self.o.valid.eq(1),
+
+            # Always ready for MIDI messages
+            self.i_midi.ready.eq(1),
+        ]
+
+        # Create a LUT from midi note to voltage (output ASQ).
+        lut = []
+        for i in range(128):
+            volts_per_note = 1.0/12.0
+            volts = i*volts_per_note - 5
+            # convert volts to audio sample
+            x = volts/(2**15/4000)
+            lut.append(fixed.Const(x, shape=ASQ)._value)
+
+        # Store it in a memory where the address is the midi note,
+        # and the data coming out is directly routed to V/Oct out.
+        m.submodules.mem = mem = Memory(
+            width=ASQ.as_shape().width, depth=len(lut), init=lut)
+        rport = mem.read_port(transparent=True)
+        m.d.comb += [
+            rport.en.eq(1),
+        ]
+
+        # Route memory straight out to our note payload.
+        m.d.sync += self.o.payload[1].as_value().eq(rport.data),
+
+        with m.If(self.i_midi.valid):
+            msg = self.i_midi.payload
+            with m.Switch(msg.midi_type):
+                with m.Case(midi.MessageType.NOTE_ON):
+                    m.d.sync += [
+                        # Gate output on
+                        self.o.payload[0].eq(fixed.Const(0.5, shape=ASQ)),
+                        # Set velocity output
+                        self.o.payload[2].as_value().eq(
+                            msg.midi_payload.note_on.velocity << 8),
+                        # Set note index in LUT
+                        rport.addr.eq(msg.midi_payload.note_on.note),
+                    ]
+                with m.Case(midi.MessageType.NOTE_OFF):
+                    # Zero gate and velocity on NOTE_OFF
+                    m.d.sync += [
+                        self.o.payload[0].eq(0),
+                        self.o.payload[2].eq(0),
+                    ]
+                with m.Case(midi.MessageType.CONTROL_CHANGE):
+                    # mod wheel is CC 1
+                    with m.If(msg.midi_payload.control_change.controller_number == 1):
+                        m.d.sync += [
+                            self.o.payload[3].as_value().eq(
+                                msg.midi_payload.control_change.data << 8),
+                        ]
+
+        return m
 
 class USB2HostTest(Elaboratable):
 
@@ -58,15 +142,26 @@ class USB2HostTest(Elaboratable):
                 hardcoded_midi_endpoint=self._HARDCODE_MIDI_BULK_ENDPOINT_ID,
         )
 
-        # Unblock MIDI out stream
-        m.d.comb += usb.o_midi_bytes.ready.eq(1)
+
+        m.submodules.midi_decode = midi_decode = midi.MidiDecode()
+        wiring.connect(m, usb.o_midi_bytes, midi_decode.i)
+
+        m.submodules.pmod0 = pmod0 = eurorack_pmod.EurorackPmod(
+                pmod_pins=platform.request("audio_ffc"),
+                hardware_r33=True,
+                touch_enabled=False)
+
+        m.submodules.audio_stream = audio_stream = eurorack_pmod.AudioStream(pmod0)
+        m.submodules.midi_cv = self.midi_cv = MidiCVTop()
+        wiring.connect(m, audio_stream.istream, self.midi_cv.i)
+        wiring.connect(m, self.midi_cv.o, audio_stream.ostream)
+        wiring.connect(m, midi_decode.o, self.midi_cv.i_midi)
 
         # XXX: this demo enables VBUS output
         m.d.comb += platform.request("usb_vbus_en").o.eq(1)
 
         if platform.ila:
             test_signal = Signal(16, reset=0xFEED)
-
             ila_signals = [
                 test_signal,
                 usb.translator.tx_valid,
@@ -78,8 +173,13 @@ class USB2HostTest(Elaboratable):
                 usb.translator.busy,
                 usb.receiver.packet_complete,
                 usb.receiver.crc_mismatch,
+                usb.receiver.stream.payload,
+                usb.receiver.stream.next,
                 usb.o_midi_bytes.valid,
                 usb.o_midi_bytes.payload,
+                midi_decode.o.payload.as_value(),
+                midi_decode.o.valid,
+                usb.midi_fifo.r_level,
                 usb.handshake_detector.detected.ack,
                 usb.handshake_detector.detected.nak,
                 usb.handshake_detector.detected.stall,
@@ -92,7 +192,7 @@ class USB2HostTest(Elaboratable):
             m.submodules += self.ila
 
             m.d.comb += [
-                self.ila.trigger.eq(usb.translator.tx_valid),
+                self.ila.trigger.eq(midi_decode.o.payload.midi_type == midi.MessageType.NOTE_ON),
                 platform.request("uart").tx.o.eq(self.ila.tx),
             ]
 

--- a/gateware/src/top/usb_host/top.py
+++ b/gateware/src/top/usb_host/top.py
@@ -20,92 +20,11 @@ from amaranth.lib.cdc             import FFSynchronizer
 
 from amaranth_future              import fixed
 
-from tiliqua.eurorack_pmod        import ASQ
 from tiliqua                      import midi, eurorack_pmod
 from tiliqua.usb_host             import *
 from tiliqua.cli                  import top_level_cli
 from tiliqua.tiliqua_platform     import RebootProvider
 from vendor.ila                   import AsyncSerialILA
-
-class MidiCVTop(wiring.Component):
-
-    """
-    Simple monophonic MIDI to CV conversion.
-
-    in: (TRS MIDI)
-    out0: Gate
-    out1: V/oct CV
-    out2: Velocity
-    out3: Mod Wheel (CC1)
-    """
-
-    i: In(stream.Signature(data.ArrayLayout(ASQ, 4)))
-    o: Out(stream.Signature(data.ArrayLayout(ASQ, 4)))
-
-    # Note: MIDI is valid at a much lower rate than audio streams
-    i_midi: In(stream.Signature(midi.MidiMessage))
-
-    def elaborate(self, platform):
-        m = Module()
-
-        m.d.comb += [
-            # Always forward our audio payload
-            self.i.ready.eq(1),
-            self.o.valid.eq(1),
-
-            # Always ready for MIDI messages
-            self.i_midi.ready.eq(1),
-        ]
-
-        # Create a LUT from midi note to voltage (output ASQ).
-        lut = []
-        for i in range(128):
-            volts_per_note = 1.0/12.0
-            volts = i*volts_per_note - 5
-            # convert volts to audio sample
-            x = volts/(2**15/4000)
-            lut.append(fixed.Const(x, shape=ASQ)._value)
-
-        # Store it in a memory where the address is the midi note,
-        # and the data coming out is directly routed to V/Oct out.
-        m.submodules.mem = mem = Memory(
-            width=ASQ.as_shape().width, depth=len(lut), init=lut)
-        rport = mem.read_port(transparent=True)
-        m.d.comb += [
-            rport.en.eq(1),
-        ]
-
-        # Route memory straight out to our note payload.
-        m.d.sync += self.o.payload[1].as_value().eq(rport.data),
-
-        with m.If(self.i_midi.valid):
-            msg = self.i_midi.payload
-            with m.Switch(msg.midi_type):
-                with m.Case(midi.MessageType.NOTE_ON):
-                    m.d.sync += [
-                        # Gate output on
-                        self.o.payload[0].eq(fixed.Const(0.5, shape=ASQ)),
-                        # Set velocity output
-                        self.o.payload[2].as_value().eq(
-                            msg.midi_payload.note_on.velocity << 8),
-                        # Set note index in LUT
-                        rport.addr.eq(msg.midi_payload.note_on.note),
-                    ]
-                with m.Case(midi.MessageType.NOTE_OFF):
-                    # Zero gate and velocity on NOTE_OFF
-                    m.d.sync += [
-                        self.o.payload[0].eq(0),
-                        self.o.payload[2].eq(0),
-                    ]
-                with m.Case(midi.MessageType.CONTROL_CHANGE):
-                    # mod wheel is CC 1
-                    with m.If(msg.midi_payload.control_change.controller_number == 1):
-                        m.d.sync += [
-                            self.o.payload[3].as_value().eq(
-                                msg.midi_payload.control_change.data << 8),
-                        ]
-
-        return m
 
 class USB2HostTest(Elaboratable):
 
@@ -152,7 +71,7 @@ class USB2HostTest(Elaboratable):
                 touch_enabled=False)
 
         m.submodules.audio_stream = audio_stream = eurorack_pmod.AudioStream(pmod0)
-        m.submodules.midi_cv = self.midi_cv = MidiCVTop()
+        m.submodules.midi_cv = self.midi_cv = midi.MonoMidiCV()
         wiring.connect(m, audio_stream.istream, self.midi_cv.i)
         wiring.connect(m, self.midi_cv.o, audio_stream.ostream)
         wiring.connect(m, midi_decode.o, self.midi_cv.i_midi)

--- a/gateware/src/top/usb_host/top.py
+++ b/gateware/src/top/usb_host/top.py
@@ -58,6 +58,9 @@ class USB2HostTest(Elaboratable):
                 hardcoded_midi_endpoint=self._HARDCODE_MIDI_BULK_ENDPOINT_ID,
         )
 
+        # Unblock MIDI out stream
+        m.d.comb += usb.o_midi_bytes.ready.eq(1)
+
         # XXX: this demo enables VBUS output
         m.d.comb += platform.request("usb_vbus_en").o.eq(1)
 
@@ -75,6 +78,8 @@ class USB2HostTest(Elaboratable):
                 usb.translator.busy,
                 usb.receiver.packet_complete,
                 usb.receiver.crc_mismatch,
+                usb.o_midi_bytes.valid,
+                usb.o_midi_bytes.payload,
                 usb.handshake_detector.detected.ack,
                 usb.handshake_detector.detected.nak,
                 usb.handshake_detector.detected.stall,

--- a/gateware/src/top/usb_host/top.py
+++ b/gateware/src/top/usb_host/top.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2024 Seb Holzapfel, apfelaudio UG <info@apfelaudio.com>
+#
+# SPDX-License-Identifier: CERN-OHL-S-2.0
+"""
+Extremely bare-bones USB MIDI host demo. EXPERIMENTAL.
+
+***WARN*** This demo hardwires the VBUS output to ON !!! ***WARN***
+
+At the moment this is only used for Tiliqua hardware validation.
+NOTE: the MIDI USB configuration and endpoint IDs are hard-coded below.
+
+At the moment, all the MIDI traffic does is blink an LED.
+A better demo would run a MIDI/CV conversion as we do for TRS MIDI.
+"""
+
+
+from amaranth                     import *
+from amaranth.build               import *
+from amaranth.lib.cdc             import FFSynchronizer
+
+from tiliqua.usb_host             import *
+from tiliqua.cli                  import top_level_cli
+from tiliqua.tiliqua_platform     import RebootProvider
+from vendor.ila                   import AsyncSerialILA
+
+class USB2HostTest(Elaboratable):
+
+    #
+    # FIXME: hardcoded device properties
+    #
+    # You can get this by looking at the device descriptors
+    # on a PC --> Find an 'Interface descriptor' with subclass
+    # 0x03 (MIDI Streaming). The parent configuration ID is the
+    # correct configuration ID. The IN (bulk) endpoint ID is the
+    # MIDI BULK endpoint ID.
+    #
+    # These will not be hardcoded when this demo is finished.
+    #
+
+    _HARDCODE_DEVICE_CONFIGURATION_ID = 1
+    _HARDCODE_MIDI_BULK_ENDPOINT_ID   = 1
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.car = car = platform.clock_domain_generator()
+        m.submodules.reboot = reboot = RebootProvider(car.clocks_hz["sync"])
+        m.submodules.btn = FFSynchronizer(
+                platform.request("encoder").s.i, reboot.button)
+
+        ulpi = platform.request(platform.default_usb_connection)
+        m.submodules.usb = usb = SimpleUSBMIDIHost(
+                bus=ulpi,
+                hardcoded_configuration_id=self._HARDCODE_DEVICE_CONFIGURATION_ID,
+                hardcoded_midi_endpoint=self._HARDCODE_MIDI_BULK_ENDPOINT_ID,
+        )
+
+        # XXX: this demo enables VBUS output
+        m.d.comb += platform.request("usb_vbus_en").o.eq(1)
+
+        if platform.ila:
+            test_signal = Signal(16, reset=0xFEED)
+
+            ila_signals = [
+                test_signal,
+                usb.translator.tx_valid,
+                usb.translator.tx_data,
+                usb.translator.tx_ready,
+                usb.translator.rx_valid,
+                usb.translator.rx_data,
+                usb.translator.rx_active,
+                usb.translator.busy,
+                usb.receiver.packet_complete,
+                usb.receiver.crc_mismatch,
+                usb.handshake_detector.detected.ack,
+                usb.handshake_detector.detected.nak,
+                usb.handshake_detector.detected.stall,
+                usb.handshake_detector.detected.nyet,
+            ]
+
+            self.ila = AsyncSerialILA(signals=ila_signals,
+                                      sample_depth=8192, divisor=521,
+                                      domain='usb', sample_rate=60e6) # ~115200 baud on USB clock
+            m.submodules += self.ila
+
+            m.d.comb += [
+                self.ila.trigger.eq(usb.translator.tx_valid),
+                platform.request("uart").tx.o.eq(self.ila.tx),
+            ]
+
+        return m
+
+if __name__ == "__main__":
+    top_level_cli(USB2HostTest, video_core=False, ila_supported=True)

--- a/gateware/src/top/usb_host/top.py
+++ b/gateware/src/top/usb_host/top.py
@@ -11,10 +11,6 @@ NOTE: the MIDI USB configuration and endpoint IDs are hard-coded below.
 
 At the moment, all the MIDI traffic is routed to CV outputs according
 to the existing example (see docstring) in `top/dsp:MidiCVTop`.
-
-State machine currently requires bitstream to boot with the USB device
-disconnected. Once you connect it, it will issue a bus reset and eventually
-start initating bulk transfers.
 """
 
 import sys

--- a/gateware/src/top/usb_host/top.py
+++ b/gateware/src/top/usb_host/top.py
@@ -11,6 +11,10 @@ NOTE: the MIDI USB configuration and endpoint IDs are hard-coded below.
 
 At the moment, all the MIDI traffic is routed to CV outputs according
 to the existing example (see docstring) in `top/dsp:MidiCVTop`.
+
+State machine currently requires bitstream to boot with the USB device
+disconnected. Once you connect it, it will issue a bus reset and eventually
+start initating bulk transfers.
 """
 
 import sys
@@ -41,9 +45,9 @@ from vendor.ila                   import AsyncSerialILA
 
 # These can be selected at top-level CLI.
 MIDI_DEVICES = {
-    # (name):         (usb configuration_id, usb_midi_endpoint_id)
-    "yamaha-cp73":    (1, 2),
-    "keylab-49":      (1, 1),
+    # (name):                 (usb configuration_id, usb_midi_endpoint_id)
+    "yamaha-cp73":            (1, 2),
+    "arturia-keylab49-mkii":  (1, 1),
 }
 
 class USB2HostTest(Elaboratable):

--- a/gateware/src/vendor/ila.py
+++ b/gateware/src/vendor/ila.py
@@ -544,7 +544,11 @@ class ILAFrontend(metaclass=ABCMeta):
 
             # Dump the each of our samples into the VCD.
             clock_time = 0
+            l_timestamp = 0
             for timestamp, sample in self.enumerate_samples():
+                if timestamp < l_timestamp:
+                    continue
+                l_timestamp = timestamp
                 for signal_name, signal_value in sample.items():
 
                     # If we're adding a clock signal, add any changes necessary since

--- a/gateware/tests/test_usb.py
+++ b/gateware/tests/test_usb.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2024 Seb Holzapfel, apfelaudio UG <info@apfelaudio.com>
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import math
+import sys
+import unittest
+
+from amaranth              import *
+from amaranth.sim          import *
+
+from tiliqua.usb_host      import *
+
+from parameterized         import parameterized
+
+from luna.gateware.test.contrib import usb_packet as testp
+
+class UsbTests(unittest.TestCase):
+
+    def _setup_token(pid, addr, endp):
+        def _token(ctx, payload):
+            ctx.set(payload.pid, pid)
+            ctx.set(payload.data.addr, addr)
+            ctx.set(payload.data.endp, endp)
+        return _token
+
+    def _setup_sof_token(frame_no):
+        def _sof(ctx, payload):
+            ctx.set(payload.pid, TokenPID.SOF)
+            ctx.set(payload.data.as_value(), frame_no)
+        return _sof
+
+    @parameterized.expand([
+        ["setup00", _setup_token(TokenPID.SETUP, 0, 0),   testp.token_packet(testp.PID.SETUP, 0, 0)],
+        ["out00",   _setup_token(TokenPID.OUT, 0, 0),     testp.token_packet(testp.PID.OUT, 0, 0)],
+        ["in00",    _setup_token(TokenPID.IN, 0, 0),      testp.token_packet(testp.PID.IN, 0, 0)],
+        ["in01",    _setup_token(TokenPID.IN, 0, 1),      testp.token_packet(testp.PID.IN, 0, 1)],
+        ["in10",    _setup_token(TokenPID.IN, 1, 0),      testp.token_packet(testp.PID.IN, 1, 0)],
+        ["in7a",    _setup_token(TokenPID.IN, 0x70, 0xa), testp.token_packet(testp.PID.IN, 0x70, 0xa)],
+        ["sof_min", _setup_sof_token(1),                  testp.sof_packet(1)],
+        ["sof_max", _setup_sof_token(2**11-1),            testp.sof_packet(2**11-1)],
+    ])
+    def test_usb_tokens(self, name, test_payload, test_ref):
+
+        """
+        Verify our USBTokenPacketGenerator emits exactly the same bits
+        as LUNA's test packet reference library.
+        """
+
+        dut = DomainRenamer({"usb": "sync"})(
+            USBTokenPacketGenerator())
+
+        async def testbench(ctx):
+            data = []
+            ctx.set(dut.tx.ready, 1)
+            test_payload(ctx, dut.i.payload)
+            ctx.set(dut.i.valid, 1)
+            await ctx.tick()
+            while ctx.get(dut.tx.valid):
+                data.append(int(ctx.get(dut.tx.data)))
+                await ctx.tick()
+            print("[packet]", [hex(d) for d in data])
+            bs = ("{0:08b}".format(data[0])[::-1] +
+                  "{0:08b}".format(data[1])[::-1] +
+                  "{0:08b}".format(data[2])[::-1])
+            print("[ref]", test_ref)
+            print("[got]", bs)
+            self.assertEqual(bs, test_ref)
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench)
+        with sim.write_vcd(vcd_file=open(f"test_usb_token_{name}.vcd", "w")):
+            sim.run()
+
+    @parameterized.expand([
+        ["get_descriptor",    SetupPayload.init_get_descriptor(0x0100, 0x0040),
+                              [0x80, 0x06, 0x00, 0x01, 0x00, 0x00, 0x40, 0x00]],
+        ["set_address",       SetupPayload.init_set_address(0x0012),
+                              [0x00, 0x05, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00]],
+        ["set_configuration", SetupPayload.init_set_configuration(0x0001),
+                              [0x00, 0x09, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00]],
+    ])
+    def test_setup_payload(self, name, payload, ref):
+
+        """
+        Verify SetupPayload produces the same bits measured using Cynthion on the wire.
+        """
+
+        v = Signal(SetupPayload, init=payload)
+        for n in range(len(ref)):
+            self.assertEqual(ref[n], (v.as_value().init >> (n*8)) & 0xFF)
+
+    def test_usb_integration(self):
+
+        """
+        Integration test to inspect what packets are spat out
+        by SimpleUSBMIDIHost, and that things are sufficiently
+        wired together for a functioning system.
+        """
+
+        dut = DomainRenamer({"usb": "sync"})(
+                SimpleUSBMIDIHost(sim=True))
+
+        async def testbench(ctx):
+            for i in range(0, 4):
+                data = []
+                ctx.set(dut.utmi.tx_ready, 1)
+                while ctx.get(~dut.utmi.tx_valid):
+                    await ctx.tick()
+                while ctx.get(dut.utmi.tx_valid):
+                    data.append(int(ctx.get(dut.utmi.tx_data)))
+                    await ctx.tick()
+                ctx.set(dut.utmi.tx_ready, 0)
+                print("[packet]", [hex(d) for d in data])
+
+        sim = Simulator(dut)
+        sim.add_clock(1e-6)
+        sim.add_testbench(testbench)
+        with sim.write_vcd(vcd_file=open("test_usb_integration.vcd", "w")):
+            sim.run()

--- a/gateware/tests/test_usb.py
+++ b/gateware/tests/test_usb.py
@@ -103,7 +103,7 @@ class UsbTests(unittest.TestCase):
                 SimpleUSBMIDIHost(sim=True))
 
         async def testbench(ctx):
-            for i in range(0, 4):
+            for i in range(0, 10):
                 data = []
                 ctx.set(dut.utmi.tx_ready, 1)
                 while ctx.get(~dut.utmi.tx_valid):


### PR DESCRIPTION
* Extremely bare-bones USB host logic intended for using Tiliqua as a USB MIDI host, initially as a MIDI/CV converter.
* Built by wiring together a lot of existing LUNA components out-of-tree and adding some things (SOF/token generation, host reset and setup phase logic).
* Intended solely for hardware validation at the moment, still requires extensive testing across different MIDI devices as well as automatically reading the descriptors to select the correct interface.
* Some unrelated improvements:
  * Fix ILA timestamping
  * Move MidiCV logic to common `midi.py` library and remove deprecated Amaranth constructs.