### PR TITLE
tiliqua_soc: add support for memory-mapped SPI flash

### DIFF
--- a/gateware/src/tiliqua/sim.py
+++ b/gateware/src/tiliqua/sim.py
@@ -162,6 +162,7 @@ def simulate(fragment, ports, harness, hw_platform, tracing=False):
                            "-Wno-TIMESCALEMOD",
                            "-Wno-PINMISSING",
                            "-Wno-ASCRANGE",
+                           "-Wno-UNSIGNED",
                            "-cc"] + tracing_flags + [
                            "--exe",
                            "--Mdir", f"{verilator_dst}",

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -76,6 +76,16 @@ class _SoldierCrabPlatform(LatticeECP5Platform):
             Subsignal("cs",   PinsN("N8", dir="o")),
             Attrs(IO_TYPE="LVCMOS33")
         ),
+
+        # Connection to our SPI flash but using quad mode (QSPI)
+        Resource("qspi_flash", 0,
+            # SCK is on pin 9; but doesn't have a traditional I/O buffer.
+            # Instead, we'll need to drive a clock into a USRMCLK instance.
+            # See interfaces/flash.py for more information.
+            Subsignal("dq",  Pins("T8 T7 M7 N7",  dir="io")),
+            Subsignal("cs",  PinsN("N8", dir="o")),
+            Attrs(IO_TYPE="LVCMOS33")
+        ),
     ]
 
 class SoldierCrabR2Platform(_SoldierCrabPlatform):

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -151,7 +151,7 @@ class TiliquaSoc(Component):
 
         self.mainram_base         = 0x00000000
         self.mainram_size         = 0x00008000
-        self.spiflash_base        = 0x10000000
+        self.spiflash_base        = 0xB0000000
         self.spiflash_size        = 0x01000000 # 128Mbit / 16MiB
         self.psram_base           = 0x20000000
         self.psram_size           = 0x02000000 # 256Mbit / 32MiB
@@ -416,16 +416,18 @@ class TiliquaSoc(Component):
         # TODO: better to move these to SVD vendor section?
         print("Generating (rust) constants ...", dst)
         with open(dst, "w") as f:
-            f.write(f"pub const CLOCK_SYNC_HZ: u32    = {self.clock_sync_hz};\n")
-            f.write(f"pub const PSRAM_BASE: usize     = 0x{self.psram_base:x};\n")
-            f.write(f"pub const PSRAM_SZ_BYTES: usize = 0x{self.psram_size:x};\n")
-            f.write(f"pub const PSRAM_SZ_WORDS: usize = PSRAM_SZ_BYTES / 4;\n")
-            f.write(f"pub const H_ACTIVE: u32         = {self.video.fb_hsize};\n")
-            f.write(f"pub const V_ACTIVE: u32         = {self.video.fb_vsize};\n")
-            f.write(f"pub const VIDEO_ROTATE_90: bool = {'true' if self.video_rotate_90 else 'false'};\n")
-            f.write(f"pub const PSRAM_FB_BASE: usize  = 0x{self.video.fb_base:x};\n")
-            f.write(f"pub const PX_HUE_MAX: i32       = 16;\n")
-            f.write(f"pub const PX_INTENSITY_MAX: i32 = 16;\n")
+            f.write(f"pub const CLOCK_SYNC_HZ: u32       = {self.clock_sync_hz};\n")
+            f.write(f"pub const PSRAM_BASE: usize        = 0x{self.psram_base:x};\n")
+            f.write(f"pub const PSRAM_SZ_BYTES: usize    = 0x{self.psram_size:x};\n")
+            f.write(f"pub const PSRAM_SZ_WORDS: usize    = PSRAM_SZ_BYTES / 4;\n")
+            f.write(f"pub const SPIFLASH_BASE: usize     = 0x{self.spiflash_base:x};\n")
+            f.write(f"pub const SPIFLASH_SZ_BYTES: usize = 0x{self.spiflash_size:x};\n")
+            f.write(f"pub const H_ACTIVE: u32            = {self.video.fb_hsize};\n")
+            f.write(f"pub const V_ACTIVE: u32            = {self.video.fb_vsize};\n")
+            f.write(f"pub const VIDEO_ROTATE_90: bool    = {'true' if self.video_rotate_90 else 'false'};\n")
+            f.write(f"pub const PSRAM_FB_BASE: usize     = 0x{self.video.fb_base:x};\n")
+            f.write(f"pub const PX_HUE_MAX: i32          = 16;\n")
+            f.write(f"pub const PX_INTENSITY_MAX: i32    = 16;\n")
 
     def regenerate_pac_from_svd(svd_path):
         """

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -214,8 +214,7 @@ class TiliquaSoc(Component):
         self.interrupt_controller.add(self.timer0, number=self.timer0_irq, name="timer0")
 
         # spiflash peripheral
-        self.spi0_bus        = spiflash.ECP5ConfigurationFlashInterface()
-        self.spi0_phy        = spiflash.SPIPHYController(provider=self.spi0_bus, domain="sync", divisor=0)
+        self.spi0_phy        = spiflash.SPIPHYController(domain="sync", divisor=0)
         self.spiflash_periph = spiflash.Peripheral(phy=self.spi0_phy, mmap_size=self.spiflash_size,
                                                    mmap_name="spiflash")
         self.wb_decoder.add(self.spiflash_periph.bus, addr=self.spiflash_base, name="spiflash")
@@ -331,7 +330,10 @@ class TiliquaSoc(Component):
         m.submodules.psram_periph = self.psram_periph
 
         # spiflash
-        m.submodules.spi0_bus = self.spi0_bus
+        if sim.is_hw(platform):
+            spi0_provider = spiflash.ECP5ConfigurationFlashProvider()
+            m.submodules.spi0_provider = spi0_provider
+            wiring.connect(m, self.spi0_phy.pins, spi0_provider.pins)
         m.submodules.spi0_phy = self.spi0_phy
         m.submodules.spiflash_periph = self.spiflash_periph
 

--- a/gateware/src/vendor/soc/cores/spiflash/__init__.py
+++ b/gateware/src/vendor/soc/cores/spiflash/__init__.py
@@ -13,9 +13,9 @@ from amaranth.lib.wiring    import connect, In, Out
 from .port                  import SPIControlPortCDC, SPIControlPortCrossbar
 from .mmap                  import SPIFlashMemoryMap
 from .controller            import SPIController
-from .phy                   import SPIPHYController, ECP5ConfigurationFlashInterface
+from .phy                   import SPIPHYController, ECP5ConfigurationFlashProvider
 
-__all__ = ["PinSignature", "Peripheral", "ECP5ConfigurationFlashInterface", "SPIPHYController"]
+__all__ = ["PinSignature", "Peripheral", "ECP5ConfigurationFlashProvider", "SPIPHYController"]
 
 class Peripheral(wiring.Component):
     """SPI Flash peripheral main module.
@@ -90,8 +90,8 @@ class Peripheral(wiring.Component):
             connect(m, phy_controller, cdc.a)
             connect(m, cdc.b, phy)
         else:
-            connect(m, phy_controller.source, phy.source)
-            connect(m, phy_controller.sink, phy.sink)
-            m.d.comb += phy.cs .eq(phy_controller.cs)
+            connect(m, phy_controller.source, phy.ctrl.source)
+            connect(m, phy_controller.sink, phy.ctrl.sink)
+            m.d.comb += phy.ctrl.cs.eq(phy_controller.cs)
 
         return m

--- a/gateware/src/vendor/soc/cores/spiflash/__init__.py
+++ b/gateware/src/vendor/soc/cores/spiflash/__init__.py
@@ -1,0 +1,97 @@
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2024 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Based on code from LiteSPI
+
+from amaranth               import Elaboratable, Module, unsigned
+from amaranth.lib           import wiring
+from amaranth.lib.wiring    import connect, In, Out
+
+from .port                  import SPIControlPortCDC, SPIControlPortCrossbar
+from .mmap                  import SPIFlashMemoryMap
+from .controller            import SPIController
+from .phy                   import SPIPHYController, ECP5ConfigurationFlashInterface
+
+__all__ = ["PinSignature", "Peripheral", "ECP5ConfigurationFlashInterface", "SPIPHYController"]
+
+class Peripheral(wiring.Component):
+    """SPI Flash peripheral main module.
+
+    This class provides a wrapper that can instantiate both ``SPIController`` and
+    ``SPIFlashMemoryMap`` and connect them to the PHY.
+
+    Both options share access to the PHY using a crossbar.
+    Also, performs CDC if a different clock is used in the PHY.
+    """
+    def __init__(self, phy, *, data_width=32, granularity=8, with_controller=True, controller_name=None,
+                 with_mmap=True, mmap_size=None, mmap_name=None, mmap_byteorder="little", domain="sync"):
+
+        self._domain    = domain
+        self.data_width = data_width
+        self.phy        = phy
+        self.cores      = []
+
+        if with_controller:
+            self.spi_controller = SPIController(
+                data_width=data_width,
+                granularity=granularity,
+                name=controller_name,
+                domain=domain,
+            )
+            self.csr = self.spi_controller.bus
+            self.cores.append(self.spi_controller)
+
+        if with_mmap:
+            self.spi_mmap = SPIFlashMemoryMap(
+                size=mmap_size,
+                data_width=data_width,
+                granularity=granularity,
+                name=mmap_name,
+                domain=domain,
+                byteorder=mmap_byteorder,
+            )
+            self.bus = self.spi_mmap.bus
+            self.cores.append(self.spi_mmap)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        phy = self.phy
+        m.submodules += self.cores
+
+        # Add crossbar when we need to share multiple cores with the same PHY.
+        if len(self.cores) > 1:
+
+            m.submodules.crossbar = crossbar = SPIControlPortCrossbar(
+                data_width=self.data_width,
+                num_ports=len(self.cores),
+                domain=self._domain,
+            )
+
+            for i, core in enumerate(self.cores):
+                connect(m, core.source, crossbar.get_port(i).source)
+                connect(m, core.sink, crossbar.get_port(i).sink)
+                m.d.comb += crossbar.get_port(i).cs  .eq(core.cs)
+
+            phy_controller = crossbar.controller
+        else:
+            phy_controller = self.cores[0]
+
+        # Add a clock domain crossing submodule if the PHY clock is different.
+        if self._domain != phy._domain:
+            m.submodules.cdc = cdc = SPIControlPortCDC(
+                data_width=self.data_width,
+                domain_a=self._domain,
+                domain_b=phy._domain,
+            )
+            connect(m, phy_controller, cdc.a)
+            connect(m, cdc.b, phy)
+        else:
+            connect(m, phy_controller.source, phy.source)
+            connect(m, phy_controller.sink, phy.sink)
+            m.d.comb += phy.cs .eq(phy_controller.cs)
+
+        return m

--- a/gateware/src/vendor/soc/cores/spiflash/controller.py
+++ b/gateware/src/vendor/soc/cores/spiflash/controller.py
@@ -1,0 +1,164 @@
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2024 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Based on code from LiteSPI
+
+from amaranth                           import Module, DomainRenamer, Signal, unsigned
+from amaranth.lib                       import wiring
+from amaranth.lib.fifo                  import SyncFIFO
+from amaranth.lib.data                  import StructLayout, View
+from amaranth.lib.wiring                import In, Out, flipped, connect
+
+from amaranth_soc                       import csr
+
+from .port                              import SPIControlPort
+
+
+class SPIController(wiring.Component):
+    """Wishbone generic SPI Flash Controller interface.
+
+    Provides a generic SPI Controller that can be interfaced using CSRs.
+    Supports multiple access modes with the help of ``width`` and ``mask`` registers which
+    can be used to configure the PHY into any supported SDR mode (single/dual/quad/octal).
+    """
+
+    class Phy(csr.Register, access="rw"):
+        """PHY control register
+
+            length : SPI transfer length in bits.
+            width  : SPI transfer bus width (1/2/4/8).
+            mask   : SPI DQ output enable mask.
+        """
+        def __init__(self, source):
+            super().__init__({
+                "length" : csr.Field(csr.action.RW, unsigned(len(source.len))),
+                "width"  : csr.Field(csr.action.RW, unsigned(len(source.width))),
+                "mask"   : csr.Field(csr.action.RW, unsigned(len(source.mask))),
+            })
+
+    class Cs(csr.Register, access="w"):
+        """SPI chip select register
+
+            select : SPI chip select signal.
+        """
+        select : csr.Field(csr.action.W, unsigned(1))
+
+    class Status(csr.Register, access="r"):
+        """Status register
+
+             rx_ready : RX FIFO contains data.
+             tx_ready : TX FIFO ready to receive data.
+        """
+        rx_ready : csr.Field(csr.action.R, unsigned(1))
+        tx_ready : csr.Field(csr.action.R, unsigned(1))
+
+    class Data(csr.Register, access="rw"):
+        """Data register
+
+            rx : Read the next byte in the RX FIFO
+            tx : Write the given byte to the TX FIFO
+        """
+        def __init__(self, width):
+            super().__init__({
+                "rx" : csr.Field(csr.action.R, unsigned(width)),
+                "tx" : csr.Field(csr.action.W, unsigned(width))
+            })
+
+
+    def __init__(self, *, data_width=32, granularity=8, rx_depth=16, tx_depth=16, name=None, domain="sync"):
+        wiring.Component.__init__(self, SPIControlPort(data_width))
+
+        self._domain   = domain
+
+        # layout description for writing to the tx fifo
+        self.tx_fifo_layout = StructLayout({
+            "data":  len(self.source.data),
+            "len":   len(self.source.len),
+            "width": len(self.source.width),
+            "mask":  len(self.source.mask),
+        })
+
+        # fifos
+        self._rx_fifo = DomainRenamer(domain)(SyncFIFO(width=len(self.sink.payload), depth=rx_depth))
+        self._tx_fifo = DomainRenamer(domain)(SyncFIFO(width=len(self.source.payload), depth=tx_depth))
+
+        # registers
+        regs = csr.Builder(addr_width=5, data_width=8)
+        self._phy    = regs.add("phy",    self.Phy(self.source))
+        self._cs     = regs.add("cs",     self.Cs())
+        self._status = regs.add("status", self.Status())
+        self._data   = regs.add("data",   self.Data(data_width))
+
+        # bridge
+        self._bridge = csr.Bridge(regs.as_memory_map())
+
+        super().__init__({
+            "bus" : In(self._bridge.bus.signature),
+        })
+        self.bus.memory_map = self._bridge.bus.memory_map
+
+
+    def elaborate(self, platform):
+        m = Module()
+        m.submodules.bridge = self._bridge
+
+        connect(m, self.bus, self._bridge.bus)
+
+        # FIFOs.
+        m.submodules.rx_fifo = rx_fifo = self._rx_fifo
+        m.submodules.tx_fifo = tx_fifo = self._tx_fifo
+
+        # Chip select generation.
+        cs = Signal()
+        with m.FSM():
+            with m.State("RISE"):
+                # Enable chip select when the CSR is set to 1 and the TX FIFO contains something.
+                m.d.comb += cs.eq(tx_fifo.r_rdy)
+                with m.If(cs == 1):
+                    m.next = "FALL"
+            with m.State("FALL"):
+                # Only disable chip select after the current TX FIFO is emptied.
+                m.d.comb += cs.eq(self._cs.f.select.w_data | tx_fifo.r_rdy)
+                with m.If(cs == 0):
+                    m.next = "RISE"
+
+        # Connect FIFOs to PHY streams.
+        tx_fifo_payload = View(self.tx_fifo_layout, tx_fifo.w_data)
+        m.d.comb += [
+            # CSRs to TX FIFO.
+            tx_fifo.w_en                   .eq(self._data.f.tx.w_stb),
+            tx_fifo_payload.data           .eq(self._data.f.tx.w_data),
+            tx_fifo_payload.len            .eq(self._phy.f.length.data),
+            tx_fifo_payload.width          .eq(self._phy.f.width.data),
+            tx_fifo_payload.mask           .eq(self._phy.f.mask.data),
+
+            # SPI chip select.
+            self.cs                        .eq(cs),
+
+            # TX FIFO to SPI PHY (PICO).
+            self.source.payload            .eq(tx_fifo.r_data),
+            self.source.valid              .eq(tx_fifo.r_rdy),
+            tx_fifo.r_en                   .eq(self.source.ready),
+
+            # SPI PHY (POCI) to RX FIFO.
+            rx_fifo.w_data                 .eq(self.sink.payload),
+            rx_fifo.w_en                   .eq(self.sink.valid),
+            self.sink.ready                .eq(rx_fifo.w_rdy),
+
+            # RX FIFO to CSRs.
+            rx_fifo.r_en                   .eq(self._data.f.rx.r_stb),
+            self._data.f.rx.r_data         .eq(rx_fifo.r_data),
+
+            # FIFOs ready flags.
+            self._status.f.rx_ready.r_data .eq(rx_fifo.r_rdy),
+            self._status.f.tx_ready.r_data .eq(tx_fifo.w_rdy),
+        ]
+
+        # Convert our sync domain to the domain requested by the user, if necessary.
+        if self._domain != "sync":
+            m = DomainRenamer({"sync": self._domain})(m)
+
+        return m

--- a/gateware/src/vendor/soc/cores/spiflash/mmap.py
+++ b/gateware/src/vendor/soc/cores/spiflash/mmap.py
@@ -1,0 +1,214 @@
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2024 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Based on code from LiteSPI
+
+from amaranth                           import Signal, Module, Cat, C, DomainRenamer
+from amaranth.utils                     import log2_int
+from amaranth.lib                       import wiring
+from amaranth.lib.wiring                import In, Out, flipped, connect
+
+from amaranth_soc                       import wishbone
+from amaranth_soc.memory                import MemoryMap
+
+from .port                              import SPIControlPort
+from .utils                             import WaitTimer
+
+
+class SPIFlashMemoryMap(wiring.Component):
+    """Wishbone Memory-mapped SPI Flash controller.
+
+    Supports sequential accesses so that command and address is only sent when necessary.
+    """
+
+    MMAP_DEFAULT_TIMEOUT = 256
+    OE_MASK = {
+        1: 0b00000001,
+        2: 0b00000011,
+        4: 0b00001111,
+        8: 0b11111111,
+    }
+
+    def __init__(self, *, size, data_width=32, granularity=8, name=None, domain="sync", byteorder="little"):
+        wiring.Component.__init__(self, SPIControlPort(data_width))
+
+        self._name     = name
+        self._size     = size
+        self._domain   = domain
+        self.byteorder = byteorder
+
+        mem_depth      = (self._size * granularity) // data_width
+        wb_addr_width  = log2_int(mem_depth)
+        wb_data_width  = data_width
+        mm_addr_width  = log2_int(self._size)
+        mm_data_width  = granularity
+
+        # self.bus = wishbone.Interface(
+        #     addr_width=wb_addr_width,
+        #     data_width=wb_data_width,
+        #     granularity=granularity,
+        # )
+
+        map = MemoryMap(addr_width=mm_addr_width, data_width=mm_data_width)
+        map.add_resource(self, name=self._name, size=self._size)
+
+
+        super().__init__({
+            "bus" : In(wishbone.Signature(
+                addr_width=wb_addr_width,
+                data_width=wb_data_width,
+                granularity=granularity,
+            )),
+        })
+        self.bus.memory_map = map
+
+    @staticmethod
+    def reverse_bytes(word):
+        nbytes = len(word) // 8
+        return Cat(word.word_select(nbytes - i - 1, 8) for i in range(nbytes))
+
+    def elaborate(self, platform):
+        m = Module()
+
+        # Flash configuration.
+        flash_read_opcode = 0xeb
+        flash_cmd_bits    = 8
+        flash_addr_bits   = 24
+        flash_data_bits   = 32
+        flash_cmd_width   = 1
+        flash_addr_width  = 4
+        flash_bus_width   = 4
+        flash_dummy_bits  = 24
+        flash_dummy_value = 0xff0000
+
+        # Aliases.
+        source = self.source
+        sink   = self.sink
+        cs     = self.cs
+        bus    = self.bus
+
+        # Burst Control.
+        burst_cs      = Signal()
+        burst_adr     = Signal(len(self.bus.adr), reset_less=True)
+        burst_timeout = WaitTimer(self.MMAP_DEFAULT_TIMEOUT, domain=self._domain)
+        m.submodules.burst_timeout = burst_timeout
+
+
+        with m.FSM(domain=self._domain):
+            with m.State("IDLE"):
+                # Keep CS active after Burst for Timeout.
+                m.d.comb += [
+                    burst_timeout.wait.eq(1),
+                    cs.eq(burst_cs),
+                ]
+                m.d.sync += burst_cs.eq(burst_cs & ~burst_timeout.done)
+                # On Bus Read access...
+                with m.If(bus.cyc & bus.stb & ~bus.we):
+                    # If CS is still active and Bus address matches previous Burst address:
+                    # Just continue the current Burst.
+                    with m.If(burst_cs & (bus.adr == burst_adr)):
+                        m.next = "BURST-REQ"
+                    # Otherwise initialize a new Burst.
+                    with m.Else():
+                        m.d.comb += cs.eq(0)
+                        m.next = "BURST-CMD"
+
+            with m.State("BURST-CMD"):
+                m.d.comb += [
+                    cs              .eq(1),
+                    source.valid    .eq(1),
+                    source.data     .eq(flash_read_opcode), # send command.
+                    source.len      .eq(flash_cmd_bits),
+                    source.width    .eq(flash_cmd_width),
+                    source.mask     .eq(self.OE_MASK[flash_cmd_width]),
+                ]
+                with m.If(source.ready):
+                    m.next = "CMD-RET"
+
+            with m.State("CMD-RET"):
+                m.d.comb += [
+                    cs              .eq(1),
+                    sink.ready      .eq(1),
+                ]
+                with m.If(sink.valid):
+                    m.next = "BURST-ADDR"
+
+            with m.State("BURST-ADDR"):
+                m.d.comb += [
+                    cs              .eq(1),
+                    source.valid    .eq(1),
+                    source.width    .eq(flash_addr_width),
+                    source.mask     .eq(self.OE_MASK[flash_addr_width]),
+                    source.data     .eq(Cat(C(0, 2), bus.adr)), # send address.
+                    source.len      .eq(flash_addr_bits),
+                ]
+                m.d.sync += [
+                    burst_cs        .eq(1),
+                    burst_adr       .eq(bus.adr),
+                ]
+                with m.If(source.ready):
+                    m.next = "ADDR-RET"
+
+            with m.State("ADDR-RET"):
+                m.d.comb += [
+                    cs              .eq(1),
+                    sink.ready      .eq(1),
+                ]
+                with m.If(sink.valid):
+                    with m.If(flash_dummy_bits == 0):
+                        m.next = "BURST-REQ"
+                    with m.Else():
+                        m.next = "DUMMY"
+
+            with m.State("DUMMY"):
+                m.d.comb += [
+                    cs              .eq(1),
+                    source.valid    .eq(1),
+                    source.width    .eq(flash_addr_width),
+                    source.mask     .eq(self.OE_MASK[flash_addr_width]),
+                    source.data     .eq(flash_dummy_value),
+                    source.len      .eq(flash_dummy_bits),
+                ]
+                with m.If(source.ready):
+                    m.next = "DUMMY-RET"
+
+            with m.State("DUMMY-RET"):
+                m.d.comb += [
+                    cs              .eq(1),
+                    sink.ready      .eq(1),
+                ]
+                with m.If(sink.valid):
+                    m.next = "BURST-REQ"
+
+            with m.State("BURST-REQ"):
+                m.d.comb += [
+                    cs              .eq(1),
+                    source.valid    .eq(1),
+                    source.width    .eq(flash_bus_width),
+                    source.mask     .eq(0),
+                    source.len      .eq(flash_data_bits),
+                ]
+                with m.If(source.ready):
+                    m.next = "BURST-DAT"
+
+            with m.State("BURST-DAT"):
+                word = self.reverse_bytes(sink.data) if self.byteorder == "little" else sink.data
+                m.d.comb += [
+                    cs              .eq(1),
+                    sink.ready      .eq(1),
+                    bus.dat_r       .eq(word),
+                ]
+                with m.If(sink.valid):
+                    m.d.comb += bus.ack.eq(1)
+                    m.d.sync += burst_adr.eq(burst_adr + 1)
+                    m.next = "IDLE"
+
+
+        # Convert our sync domain to the domain requested by the user, if necessary.
+        if self._domain != "sync":
+            m = DomainRenamer({"sync": self._domain})(m)
+
+        return m

--- a/gateware/src/vendor/soc/cores/spiflash/phy.py
+++ b/gateware/src/vendor/soc/cores/spiflash/phy.py
@@ -1,0 +1,269 @@
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2024 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Based on code from LiteSPI
+
+from amaranth               import *
+from amaranth.lib           import wiring
+from amaranth.utils         import bits_for
+from amaranth.lib.wiring    import connect, In, Out
+
+from .port              import SPIControlPort
+from .utils             import WaitTimer
+
+class SPIPinSignature(wiring.Signature):
+    def __init__(self):
+        super().__init__({
+            "dq" : In(
+                wiring.Signature({
+                    "i"  :  In  (unsigned(4)),
+                    "o"  :  Out (unsigned(4)),
+                    "oe" :  Out (unsigned(1)),
+                })
+            ),
+            "cs" : Out(
+                wiring.Signature({
+                    "o"  :  Out (unsigned(1)),
+                })
+            ),
+            "sck" : Out(
+                wiring.Signature({
+                    "o"  :  Out (unsigned(1)),
+                })
+            ),
+        })
+
+
+class SPIPHYController(wiring.Component):
+    """Provides a generic PHY that can be used by a SPI flash controller.
+
+    It supports single/dual/quad/octal output reads from the flash chips.
+    """
+    def __init__(self, provider, data_width=32, divisor=0, domain="sync"):
+        super().__init__(SPIControlPort(data_width).flip())
+        self.divisor = divisor  # SPI frequency is clk / (2*(1+divisor))
+        self.provider = provider
+        self._domain = domain
+
+    def elaborate(self, platform):
+        m = Module()
+
+        pads   = self.provider.pins
+        sink   = self.sink
+        source = self.source
+
+        # Clock Generator.
+        m.submodules.clkgen = clkgen = SPIClockGenerator(self.divisor, domain=self._domain)
+        spi_clk_divisor = self.divisor
+
+        # CS control: ensure cs_delay cycles between XFers.
+        cs_delay = 0
+        cs_enable = Signal()
+        if cs_delay > 0:
+            m.submodules.cs_timer = cs_timer  = WaitTimer(cs_delay + 1, domain=self._domain)
+            m.d.comb += [
+                cs_timer.wait    .eq(self.cs),
+                cs_enable        .eq(cs_timer.done),
+            ]
+        else:
+            m.d.comb += cs_enable.eq(self.cs)
+
+        # I/Os.
+        dq_o  = Signal.like(pads.dq.o)
+        dq_i  = Signal.like(pads.dq.i)
+        dq_oe = Signal.like(pads.dq.oe)
+        m.d.sync += [
+            pads.sck.o  .eq(clkgen.clk),
+            pads.cs.o   .eq(cs_enable),
+            pads.dq.o   .eq(dq_o),
+            pads.dq.oe  .eq(dq_oe),
+            dq_i        .eq(pads.dq.i),
+        ]
+        if hasattr(pads.cs, 'oe'):
+            m.d.comb += pads.cs.oe.eq(1)
+
+        # Data Shift Registers.
+        sr_cnt       = Signal(8, reset_less=True)
+        sr_out_load  = Signal()
+        sr_out_shift = Signal()
+        sr_out       = Signal(len(source.data), reset_less=True)
+        sr_in_shift  = Signal()
+        sr_in        = Signal(len(source.data), reset_less=True)
+
+        # Data Out Generation/Load/Shift.
+        m.d.comb += dq_oe.eq(source.mask)
+        with m.Switch(source.width):
+            with m.Case(1):
+                m.d.comb += dq_o.eq(sr_out[-1:])
+            with m.Case(2):
+                m.d.comb += dq_o.eq(sr_out[-2:])
+            with m.Case(4):
+                m.d.comb += dq_o.eq(sr_out[-4:])
+            with m.Case(8):
+                m.d.comb += dq_o.eq(sr_out[-8:])
+
+        with m.If(sr_out_load):
+            m.d.sync += sr_out.eq(source.data << (len(source.data) - source.len).as_unsigned())
+
+        with m.If(sr_out_shift):
+            with m.Switch(source.width):
+                with m.Case(1):
+                    m.d.sync += sr_out.eq(Cat(C(0, 1), sr_out))
+                with m.Case(2):
+                    m.d.sync += sr_out.eq(Cat(C(0, 2), sr_out))
+                with m.Case(4):
+                    m.d.sync += sr_out.eq(Cat(C(0, 4), sr_out))
+                with m.Case(8):
+                    m.d.sync += sr_out.eq(Cat(C(0, 8), sr_out))
+
+        # Data In Shift.
+        with m.If(sr_in_shift):
+            with m.Switch(source.width):
+                with m.Case(1):
+                    m.d.sync += sr_in.eq(Cat(dq_i[1], sr_in))  # 1 = peripheral output
+                with m.Case(2):
+                    m.d.sync += sr_in.eq(Cat(dq_i[:2], sr_in))
+                with m.Case(4):
+                    m.d.sync += sr_in.eq(Cat(dq_i[:4], sr_in))
+                with m.Case(8):
+                    m.d.sync += sr_in.eq(Cat(dq_i[:8], sr_in))
+
+
+        m.d.comb += sink.data.eq(sr_in)
+
+        with m.FSM(domain=self._domain):
+
+            with m.State("WAIT-CMD-DATA"):
+                # Wait for CS and a CMD from the Core.
+                with m.If(cs_enable & source.valid):
+                    # Load Shift Register Count/Data Out.
+                    m.d.sync += sr_cnt.eq(source.len - source.width)
+                    m.d.comb += sr_out_load.eq(1)
+                    # Start XFER.
+                    m.next = 'XFER'
+
+            with m.State('XFER'):
+                m.d.comb += [
+                    clkgen.en   .eq(1),
+                    # Data in / out shift.
+                    sr_in_shift .eq(clkgen.sample),
+                    sr_out_shift.eq(clkgen.update),
+                ]
+
+                # Shift register count update/check.
+                with m.If(clkgen.update):
+                    m.d.sync += sr_cnt.eq(sr_cnt - source.width)
+                    # End xfer.
+                    with m.If(sr_cnt == 0):
+                        m.next = 'XFER-END'
+
+            with m.State('XFER-END'):
+                # Last data already captured in XFER when divisor > 0 so only capture for divisor == 0.
+                with m.If((spi_clk_divisor > 0) | clkgen.sample):
+                    # Accept CMD.
+                    m.d.comb += source.ready.eq(1)
+                    # Capture last data (only for spi_clk_divisor == 0).
+                    m.d.comb += sr_in_shift.eq(spi_clk_divisor == 0)
+                    # Send Status/Data to Core.
+                    m.next = "SEND-STATUS-DATA"
+
+            with m.State('SEND-STATUS-DATA'):
+                # Send data in to core and return to IDLE when accepted.
+                m.d.comb += sink.valid.eq(1)
+                with m.If(sink.ready):
+                    m.next = 'WAIT-CMD-DATA'
+
+        # Convert our sync domain to the domain requested by the user, if necessary.
+        if self._domain != "sync":
+            m = DomainRenamer({"sync": self._domain})(m)
+
+        return m
+
+
+
+class SPIClockGenerator(Elaboratable):
+    def __init__(self, divisor, domain="sync"):
+        self._domain      = domain
+        self.div          = divisor
+        self.en           = Signal()
+        self.clk          = Signal()
+        self.sample       = Signal()
+        self.update       = Signal()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        div          = self.div
+        cnt_width    = bits_for(div)
+        cnt          = Signal(cnt_width)
+        posedge      = Signal()
+        negedge      = Signal()
+        posedge_reg  = Signal()
+        posedge_reg2 = Signal()
+
+        m.d.comb += [
+            posedge     .eq(self.en & ~self.clk & (cnt == div)),
+            negedge     .eq(self.en &  self.clk & (cnt == div)),
+            self.update .eq(negedge),
+            self.sample .eq(posedge_reg2),
+        ]
+
+        # Delayed edge to account for IO register delays.
+        m.d.sync += [
+            posedge_reg    .eq(posedge),
+            posedge_reg2   .eq(posedge_reg),
+        ]
+
+        with m.If(self.en):
+            with m.If(cnt < div):
+                m.d.sync += cnt.eq(cnt + 1)
+            with m.Else():
+                m.d.sync += [
+                    cnt.eq(0),
+                    self.clk.eq(~self.clk),
+                ]
+        with m.Else():
+            m.d.sync += [
+                cnt.eq(0),
+                self.clk.eq(0),
+            ]
+
+        # Convert our sync domain to the domain requested by the user, if necessary.
+        if self._domain != "sync":
+            m = DomainRenamer({"sync": self._domain})(m)
+
+        return m
+
+
+
+class ECP5ConfigurationFlashInterface(wiring.Component):
+    """ Gateware that creates a connection to an MSPI configuration flash.
+
+    Automatically uses appropriate platform resources; this abstracts away details
+    necessary to e.g. drive the MCLK lines on an ECP5, which has special handling.
+    """
+    def __init__(self):
+        super().__init__({
+            "pins": In(SPIPinSignature())
+        })
+
+    def elaborate(self, platform):
+        m = Module()
+
+        spi = platform.request("qspi_flash")
+        m.d.comb += [
+            self.pins.dq.i.eq(spi.dq.i),
+            spi.dq.o.eq(self.pins.dq.o),
+            spi.dq.oe.eq(self.pins.dq.oe),
+            spi.cs.o.eq(self.pins.cs.o),
+        ]
+
+        # Get the ECP5 block that's responsible for driving the MCLK pin,
+        # and drive it using our SCK line.
+        user_mclk = Instance('USRMCLK', i_USRMCLKI=self.pins.sck.o, i_USRMCLKTS=0)
+        m.submodules += user_mclk
+
+        return m

--- a/gateware/src/vendor/soc/cores/spiflash/port.py
+++ b/gateware/src/vendor/soc/cores/spiflash/port.py
@@ -1,0 +1,172 @@
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2024 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Based on code from LiteSPI
+
+from amaranth               import Module, Signal, Cat, EnableInserter
+from amaranth.lib.fifo      import AsyncFIFO
+from amaranth.lib.cdc       import FFSynchronizer
+from amaranth.lib           import wiring
+from amaranth.lib.wiring    import In, Out, connect
+
+from .utils                 import RoundRobin
+
+
+#
+# Signatures.
+#
+
+class StreamCore2PHY(wiring.Signature):
+    def __init__(self, data_width):
+        self._data_width = data_width
+        members = {
+            "data":  Out(data_width),
+            "len":   Out(6),
+            "width": Out(4),
+            "mask":  Out(8),
+            "valid": Out(1),
+            "ready": In(1),
+        }
+        super().__init__(members)
+
+    @property
+    def data_width(self):
+        return self._data_width
+
+    def __eq__(self, other):
+        return isinstance(other, StreamCore2PHY) and self.data_width == other.data_width
+
+    def __repr__(self):
+        return f"StreamCore2PHY({self.data_width})"
+
+    def create(self, *, path=None, src_loc_at=0):
+        return StreamCore2PHYInterface(self, path=path, src_loc_at=1 + src_loc_at)
+
+class StreamCore2PHYInterface(wiring.PureInterface):
+    @property
+    def payload(self):
+        """ Joint signal with all data. """
+        return Cat(self.data, self.len, self.width, self.mask)
+
+
+class StreamPHY2Core(wiring.Signature):
+    def __init__(self, data_width):
+        self._data_width = data_width
+        members = {
+            "data":  Out(data_width),
+            "valid": Out(1),
+            "ready": In(1),
+        }
+        super().__init__(members)
+
+    @property
+    def data_width(self):
+        return self._data_width
+
+    def __eq__(self, other):
+        return isinstance(other, StreamPHY2Core) and self.data_width == other.data_width
+
+    def __repr__(self):
+        return f"StreamPHY2Core({self.data_width})"
+
+    def create(self, *, path=None, src_loc_at=0):
+        return StreamPHY2CoreInterface(self, path=path, src_loc_at=1 + src_loc_at)
+
+class StreamPHY2CoreInterface(wiring.PureInterface):
+    @property
+    def payload(self):
+        """ Joint signal with all data. """
+        return self.data
+
+
+class SPIControlPort(wiring.Signature):
+    def __init__(self, data_width):
+        super().__init__({
+            "source": Out(StreamCore2PHY(data_width)),
+            "sink":   In(StreamPHY2Core(data_width)),
+            "cs":     Out(1),
+        })
+
+
+#
+# SPI control port utilities.
+#
+
+class SPIControlPortCrossbar(wiring.Component):
+    """ Merge multiple SPIControlPorts with a round-robin scheduler. """
+
+    def __init__(self, *, data_width=32, num_ports=1, domain="sync"):
+        self._domain = domain
+        self._num_ports = num_ports
+
+        super().__init__(dict(
+            controller=Out(SPIControlPort(data_width)),
+            **{f"slave{i}": In(SPIControlPort(data_width)) for i in range(num_ports)}
+        ))
+
+    def get_port(self, index):
+        return getattr(self, f"slave{index}")
+
+    def elaborate(self, platform):
+        m = Module()
+
+        grant_update = Signal()
+        m.submodules.rr = rr = EnableInserter(grant_update)(RoundRobin(count=self._num_ports))
+        m.d.comb += rr.requests.eq(Cat(self.get_port(i).cs for i in range(self._num_ports)))
+
+        # Multiplexer.
+        with m.Switch(rr.grant):
+            for i in range(self._num_ports):
+                with m.Case(i):
+                    connect(m, wiring.flipped(self.get_port(i)), wiring.flipped(self.controller))
+                    m.d.comb += grant_update.eq(~rr.valid | ~rr.requests[i])
+
+        return m
+
+
+class SPIControlPortCDC(wiring.Component):
+    """ Converts one SPIControlPort between clock domains. """
+
+    def __init__(self, *, data_width=32, domain_a="sync", domain_b="sync", depth=4):
+        super().__init__({
+            "a": In(SPIControlPort(data_width)),
+            "b": Out(SPIControlPort(data_width)),
+        })
+        self.domain_a = domain_a
+        self.domain_b = domain_b
+        self.depth    = depth
+
+    def elaborate(self, platform):
+        m = Module()
+        a, b = self.a, self.b
+
+        tx_cdc = AsyncFIFO(width=len(a.source.payload), depth=self.depth, w_domain=self.domain_a, r_domain=self.domain_b)
+        rx_cdc = AsyncFIFO(width=len(b.sink.data), depth=self.depth, w_domain=self.domain_b, r_domain=self.domain_a)
+        cs_cdc = FFSynchronizer(a.cs, b.cs, o_domain=self.domain_b)
+
+        m.submodules.tx_cdc = tx_cdc
+        m.submodules.rx_cdc = rx_cdc
+        m.submodules.cs_cdc = cs_cdc
+
+        m.d.comb += [
+            # Wire TX path.
+            tx_cdc.w_data       .eq(a.source.payload),
+            tx_cdc.w_en         .eq(a.source.valid),
+            a.source.ready      .eq(tx_cdc.w_rdy),
+            b.source.payload    .eq(tx_cdc.r_data),
+            b.source.valid      .eq(tx_cdc.r_rdy),
+            tx_cdc.r_en         .eq(b.source.ready),
+
+            # Wire RX path.
+            rx_cdc.w_data       .eq(b.sink.data),
+            rx_cdc.w_en         .eq(b.sink.valid),
+            b.sink.ready        .eq(rx_cdc.w_rdy),
+            a.sink.data         .eq(rx_cdc.r_data),
+            a.sink.valid        .eq(rx_cdc.r_rdy),
+            rx_cdc.r_en         .eq(a.sink.ready),
+        ]
+
+        return m

--- a/gateware/src/vendor/soc/cores/spiflash/utils.py
+++ b/gateware/src/vendor/soc/cores/spiflash/utils.py
@@ -1,0 +1,93 @@
+#
+# This file is part of LUNA.
+#
+# Copyright (c) 2024 Great Scott Gadgets <info@greatscottgadgets.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Based on code from LiteSPI
+
+from amaranth           import Elaboratable, Module, Signal, DomainRenamer
+from amaranth.utils     import bits_for
+
+
+class RoundRobin(Elaboratable):
+    """Round-robin scheduler.
+
+    For a given set of requests, the round-robin scheduler will
+    grant one request. Once it grants a request, if any other
+    requests are active, it grants the next active request with
+    a greater number, restarting from zero once it reaches the
+    highest one.
+
+    Use :class:`EnableInserter` to control when the scheduler
+    is updated.
+
+    Parameters
+    ----------
+    count : int
+        Number of requests.
+
+    Attributes
+    ----------
+    requests : Signal(count), in
+        Set of requests.
+    grant : Signal(range(count)), out
+        Number of the granted request. Does not change if there are no
+        active requests.
+    valid : Signal(), out
+        Asserted if grant corresponds to an active request. Deasserted
+        otherwise, i.e. if no requests are active.
+    """
+    def __init__(self, *, count):
+        if not isinstance(count, int) or count < 0:
+            raise ValueError("Count must be a non-negative integer, not {!r}"
+                             .format(count))
+        self.count    = count
+
+        self.requests = Signal(count)
+        self.grant    = Signal(range(count))
+        self.valid    = Signal()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        with m.Switch(self.grant):
+            for i in range(self.count):
+                with m.Case(i):
+                    for pred in reversed(range(i)):
+                        with m.If(self.requests[pred]):
+                            m.d.sync += self.grant.eq(pred)
+                    for succ in reversed(range(i + 1, self.count)):
+                        with m.If(self.requests[succ]):
+                            m.d.sync += self.grant.eq(succ)
+
+        m.d.sync += self.valid.eq(self.requests.any())
+
+        return m
+
+
+class WaitTimer(Elaboratable):
+    def __init__(self, t, domain="sync"):
+        self._domain = domain
+        self.t    = t
+        self.wait = Signal()
+        self.done = Signal()
+
+    def elaborate(self, platform):
+        m = Module()
+
+        t     = int(self.t)
+        count = Signal(bits_for(t), reset=t)
+
+        m.d.comb += self.done.eq(count == 0)
+        with m.If(self.wait):
+            with m.If(~self.done):
+                m.d.sync += count.eq(count - 1)
+        with m.Else():
+            m.d.sync += count.eq(count.reset)
+
+        # Convert our sync domain to the domain requested by the user, if necessary.
+        if self._domain != "sync":
+            m = DomainRenamer({"sync": self._domain})(m)
+
+        return m


### PR DESCRIPTION
* Add memory-mapped SPI flash support (from `luna-soc`)
* Add a simple test/benchmark to `selftest` bitstream.
* Some changes to `ECP5ConfigurationFlashProvider` to have the pin interfaces still function in simulation.