### PR TITLE
tiliqua/i2c: rewrite audio interface i2c state machine

### DIFF
--- a/gateware/src/rs/lib/src/ui.rs
+++ b/gateware/src/rs/lib/src/ui.rs
@@ -135,10 +135,13 @@ macro_rules! impl_ui {
                             }
                         } else {
                             self.pmod.led_all_auto();
+                            // Override LEDs with touch value if no jack inserted.
                             let touch = self.pmod.touch();
                             for n in 0..8 {
-                                if (self.touch_led_mask & (1<<n)) != 0 {
-                                    self.pmod.led_set_manual(n,(touch[n]>>2) as i8);
+                                if (self.pmod.jack() & (1<<n)) == 0 {
+                                    if (self.touch_led_mask & (1<<n)) != 0 {
+                                        self.pmod.led_set_manual(n,(touch[n]>>2) as i8);
+                                    }
                                 }
                             }
                         }

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -13,7 +13,7 @@ from amaranth.lib               import wiring, data, stream
 from amaranth.lib.wiring        import In, Out
 from amaranth.lib.fifo          import AsyncFIFOBuffered
 from amaranth.lib.cdc           import FFSynchronizer
-from amaranth.lib.memory   import Memory
+from amaranth.lib.memory        import Memory
 
 from tiliqua                    import i2c
 from vendor                     import i2c as vendor_i2c
@@ -332,10 +332,13 @@ class I2CMaster(wiring.Component):
             #
 
             with m.State('STARTUP-DELAY'):
-                with m.If(startup_delay == 600_000):
+                if platform is not None:
+                    with m.If(startup_delay == 600_000):
+                        m.next = init
+                    with m.Else():
+                        m.d.sync += startup_delay.eq(startup_delay+1)
+                else:
                     m.next = init
-                with m.Else():
-                    m.d.sync += startup_delay.eq(startup_delay+1)
 
             #
             # PCA9557 init

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -177,7 +177,7 @@ class I2CMaster(wiring.Component):
     ]
 
     def __init__(self):
-        self.i2c_stream = i2c.I2CStreamer(period_cyc=4)
+        self.i2c_stream = i2c.I2CStreamer(period_cyc=512)
         super().__init__({
             "pins":   wiring.Out(vendor_i2c.I2CPinSignature()),
             "jack":   wiring.Out(self.N_JACKS),
@@ -471,14 +471,14 @@ class EurorackPmod(wiring.Component):
             self.touch[5].eq(i2c_master.touch[5]),
             self.touch[6].eq(i2c_master.touch[6]),
             self.touch[7].eq(i2c_master.touch[7]),
-            i2c_master.led[0].eq(self.sample_i[0]),
-            i2c_master.led[1].eq(self.sample_i[1]),
-            i2c_master.led[2].eq(self.sample_i[2]),
-            i2c_master.led[3].eq(self.sample_i[3]),
-            i2c_master.led[4].eq(self.sample_o[0]),
-            i2c_master.led[5].eq(self.sample_o[1]),
-            i2c_master.led[6].eq(self.sample_o[2]),
-            i2c_master.led[7].eq(self.sample_o[3]),
+            i2c_master.led[0].eq(self.sample_i[0]>>9),
+            i2c_master.led[1].eq(self.sample_i[1]>>9),
+            i2c_master.led[2].eq(self.sample_i[2]>>9),
+            i2c_master.led[3].eq(self.sample_i[3]>>9),
+            i2c_master.led[4].eq(self.sample_o[0]>>9),
+            i2c_master.led[5].eq(self.sample_o[1]>>9),
+            i2c_master.led[6].eq(self.sample_o[2]>>9),
+            i2c_master.led[7].eq(self.sample_o[3]>>9),
         ]
 
         # CODEC ser-/deserialiser. Sample rate derived from these clocks.

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -177,7 +177,7 @@ class I2CMaster(wiring.Component):
     ]
 
     def __init__(self):
-        self.i2c_stream = i2c.I2CStreamer(period_cyc=512)
+        self.i2c_stream = i2c.I2CStreamer(period_cyc=256)
         super().__init__({
             "pins":   wiring.Out(vendor_i2c.I2CPinSignature()),
             "jack":   wiring.Out(self.N_JACKS),

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -225,10 +225,10 @@ class I2CMaster(wiring.Component):
                     rd_port.en.eq(1),
                     rd_port.addr.eq(cnt),
                 ]
+                m.d.sync += cnt.eq(cnt+1)
                 with m.If(cnt != len(data) + 1):
-                    m.d.sync += cnt.eq(cnt+1)
                     m.d.comb += [
-                        i2c.i.valid.eq(1),
+                        i2c.i.valid.eq(cnt != 0),
                         i2c.i.payload.rw.eq(0), # Write
                         i2c.i.payload.data.eq(rd_port.data),
                         i2c.i.payload.last.eq(cnt == (len(data)-1)),

--- a/gateware/src/tiliqua/eurorack_pmod.py
+++ b/gateware/src/tiliqua/eurorack_pmod.py
@@ -280,16 +280,10 @@ class I2CMaster(wiring.Component):
         with m.FSM(init='STARTUP-DELAY') as fsm:
 
             #
-            # CY8CMBR3108 init (SW_RESET)
-            # Config is not flashed here, it is assumed touch config
-            # in CY8CMBR3108 NVM is already flashed
+            # AK4619VN init
             #
-            # TODO: verify this against checksum read?
-            #
-
-            init, _,   ix  = i2c_addr (m, ix, self.CY8CMBR3108_ADDR)
-            _,    _,   ix  = i2c_write(m, ix, 0x86)
-            _,    _,   ix  = i2c_write(m, ix, 0xff, last=True)
+            init, _,   ix  = i2c_addr (m, ix, self.AK4619VN_ADDR)
+            _,    _,   ix  = i2c_w_arr(m, ix, self.AK4619VN_CFG)
             _,    _,   ix  = i2c_wait (m, ix)
 
             #
@@ -301,24 +295,6 @@ class I2CMaster(wiring.Component):
                     m.next = init
                 with m.Else():
                     m.d.sync += startup_delay.eq(startup_delay+1)
-
-            #
-            # CYMBR init retries
-            #
-
-            cur, nxt, ix = state_id(ix)
-            with m.State(cur):
-                with m.If(i2c.status.error):
-                    m.next = init
-                with m.Else():
-                    m.next = nxt
-
-            #
-            # AK4619VN init
-            #
-            _,   _,   ix  = i2c_addr (m, ix, self.AK4619VN_ADDR)
-            _,   _,   ix  = i2c_w_arr(m, ix, self.AK4619VN_CFG)
-            _,   _,   ix  = i2c_wait (m, ix)
 
             #
             # PCA9557 init

--- a/gateware/src/tiliqua/eurorack_pmod_peripheral.py
+++ b/gateware/src/tiliqua/eurorack_pmod_peripheral.py
@@ -81,8 +81,23 @@ class Peripheral(wiring.Component):
 
         connect(m, flipped(self.bus), self._bridge.bus)
 
-        m.d.comb += self._touch_err.f.value.r_data.eq(self.pmod.touch_err)
+        m.d.comb += [
+            self._touch_err.f.value.r_data.eq(self.pmod.touch_err),
+            self._jack.f.jack.r_data.eq(self.pmod.jack),
+            self._eeprom.f.mfg.r_data.eq(self.pmod.eeprom_mfg),
+            self._eeprom.f.dev.r_data.eq(self.pmod.eeprom_dev),
+            self._eeprom.f.serial.r_data.eq(self.pmod.eeprom_serial),
+        ]
 
+        with m.If(self._led_mode.f.led.w_stb):
+            m.d.sync += self.pmod.led_mode.eq(self._led_mode.f.led.w_data)
+
+        for i in range(8):
+            m.d.comb += self._touch[i].f.touch.r_data.eq(self.pmod.touch[i])
+            with m.If(self._led[i].f.led.w_stb):
+                m.d.sync += self.pmod.led[i].eq(self._led[i].f.led.w_data)
+
+        # Audio domain signals need synchronizers
         for i in range(4):
             m.submodules += FFSynchronizer(self.pmod.sample_adc[i], self._sample_adc[i].f.sample.r_data, reset=0)
             m.submodules += FFSynchronizer(self.pmod.sample_i[i], self._sample_i[i].f.sample.r_data, reset=0)
@@ -90,19 +105,5 @@ class Peripheral(wiring.Component):
                 with m.If(self._sample_o[i].f.sample.w_stb):
                     m.d.sync += self.pmod.sample_o[i].eq(self._sample_o[i].f.sample.w_data)
 
-        for i in range(8):
-            m.submodules += FFSynchronizer(self.pmod.touch[i], self._touch[i].f.touch.r_data, reset=0)
-
-        with m.If(self._led_mode.f.led.w_stb):
-            m.d.sync += self.pmod.led_mode.eq(self._led_mode.f.led.w_data)
-
-        for i in range(8):
-            with m.If(self._led[i].f.led.w_stb):
-                m.d.sync += self.pmod.led[i].eq(self._led[i].f.led.w_data)
-
-        m.submodules += FFSynchronizer(self.pmod.jack, self._jack.f.jack.r_data, reset=0)
-        m.submodules += FFSynchronizer(self.pmod.eeprom_mfg, self._eeprom.f.mfg.r_data, reset=0)
-        m.submodules += FFSynchronizer(self.pmod.eeprom_dev, self._eeprom.f.dev.r_data, reset=0)
-        m.submodules += FFSynchronizer(self.pmod.eeprom_serial, self._eeprom.f.serial.r_data, reset=0)
 
         return m

--- a/gateware/src/tiliqua/i2c.py
+++ b/gateware/src/tiliqua/i2c.py
@@ -92,8 +92,10 @@ class I2CStreamer(wiring.Component):
 
         current_transaction_rw = Signal()
 
+        err  = Signal()
         done = Signal()
         m.d.comb += done.eq(self._transactions.level == 0)
+        m.d.comb += self.status.error.eq(err)
 
         with m.FSM() as fsm:
 
@@ -105,7 +107,7 @@ class I2CStreamer(wiring.Component):
                     m.next = 'START'
 
             with m.State('START'):
-                m.d.sync += self.status.error.eq(0)
+                m.d.sync += err.eq(0)
                 with m.If(~i2c.busy):
                     m.d.comb += i2c.start.eq(1),
                     m.next = 'SEND_DEV_ADDRESS'
@@ -183,7 +185,7 @@ class I2CStreamer(wiring.Component):
 
             with m.State("ABORT"):
                 with m.If(~i2c.busy):
-                    m.d.sync += self.status.error.eq(1)
+                    m.d.sync += err.eq(1)
                     m.d.comb += i2c.stop.eq(1)
                     m.next = "DRAIN_FIFOS"
 

--- a/gateware/src/tiliqua/i2c.py
+++ b/gateware/src/tiliqua/i2c.py
@@ -8,23 +8,16 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 from amaranth                    import *
-from amaranth.lib                import wiring
-from amaranth.lib.wiring         import Component, In, Out, flipped, connect
+from amaranth.lib                import wiring, data, stream
+from amaranth.lib.wiring         import Component, In, Out, flipped
 from amaranth.lib.fifo           import SyncFIFOBuffered
 from amaranth_soc                import csr, gpio
-from vendor.i2c                  import I2CInitiator
-
-class PinSignature(wiring.Signature):
-    def __init__(self):
-        super().__init__({
-            "sda":  Out(gpio.PinSignature()),
-            "scl":  Out(gpio.PinSignature()),
-        })
+from vendor.i2c                  import I2CInitiator, I2CPinSignature
 
 class Provider(Component):
     def __init__(self):
         super().__init__({
-            "pins": In(PinSignature())
+            "pins": In(I2CPinSignature())
         })
 
     def elaborate(self, platform):
@@ -38,6 +31,170 @@ class Provider(Component):
             i2c.scl.oe.eq(self.pins.scl.oe),
             self.pins.scl.i.eq(i2c.scl.i),
         ]
+        return m
+
+class I2CStreamer(wiring.Component):
+
+    """
+    Perform a stream of I2C transactions. Broadly speaking:
+    1) Set `address` to the device address. This can be changed, just not while the core is busy.
+    2) Enqueue up to `transaction_depth` I2C read/writes to that device to the `i` stream.
+    3) As soon as a transaction is enqueued with the `last` bit set -
+        - `busy` asserts. Do not enqueue or modify any signals to this core until `busy` clears.
+        - The core drains the transaction FIFO until all are consumed.
+        - Read operations push a single byte to the `o` stream per read.
+        - NACK errors abort the whole process and drain all FIFOs.
+    More detail on how transactions are dilineated can be found in the `i2c.Peripheral` core below.
+    """
+
+    class I2CTransaction(data.Struct):
+        last: unsigned(1)
+        rw:   unsigned(1)
+        data: unsigned(8)
+
+    class I2CStatus(data.Struct):
+        busy:  unsigned(1)
+        error: unsigned(1)
+
+    def __init__(self, period_cyc=None, clk_stretch=False,
+                 transaction_depth=32, rx_depth=8, **kwargs):
+        self.period_cyc = period_cyc
+        self.clk_stretch = clk_stretch
+        self._transactions = SyncFIFOBuffered(width=10, depth=transaction_depth)
+        self._rx_fifo = SyncFIFOBuffered(width=8, depth=rx_depth)
+        super().__init__({
+            "pins":    Out(I2CPinSignature()),
+            "address": In(7),
+            "status":  Out(self.I2CStatus),
+            "i":       In(stream.Signature(self.I2CTransaction)),
+            "o":       Out(stream.Signature(unsigned(8))),
+        })
+        self.i2c = I2CInitiator(pads=self.pins, period_cyc=self.period_cyc, clk_stretch=self.clk_stretch)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        m.submodules.rx_fifo = self._rx_fifo
+        m.submodules.transactions = self._transactions
+        m.submodules.i2c = i2c = self.i2c
+
+        wiring.connect(m, wiring.flipped(self.i), self._transactions.w_stream)
+        wiring.connect(m, self._rx_fifo.r_stream, wiring.flipped(self.o))
+
+        tx = Signal.like(self.i.payload)
+        m.d.comb += [
+            tx.eq(self._transactions.r_stream.payload),
+            i2c.start.eq(0),
+            i2c.write.eq(0),
+            i2c.read.eq(0),
+            i2c.stop.eq(0),
+        ]
+
+        current_transaction_rw = Signal()
+
+        done = Signal()
+        m.d.comb += done.eq(self._transactions.level == 0)
+
+        with m.FSM() as fsm:
+
+            # We're busy whenever we're not IDLE; indicate so.
+            m.d.comb += self.status.busy.eq(~fsm.ongoing('IDLE'))
+
+            with m.State('IDLE'):
+                with m.If(self.i.ready & self.i.valid & self.i.payload.last):
+                    m.next = 'START'
+
+            with m.State('START'):
+                m.d.sync += self.status.error.eq(0)
+                with m.If(~i2c.busy):
+                    m.d.comb += i2c.start.eq(1),
+                    m.next = 'SEND_DEV_ADDRESS'
+
+            with m.State("SEND_DEV_ADDRESS"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        i2c.data_i     .eq((self.address << 1) | tx.rw),
+                        i2c.write      .eq(1),
+                    ]
+                    m.d.sync += current_transaction_rw.eq(tx.rw)
+                    m.next = "ACK_DEV_ADDRESS"
+
+            with m.State("ACK_DEV_ADDRESS"):
+                with m.If(~i2c.busy):
+                    with m.If(~i2c.ack_o):
+                        m.next = "ABORT"
+                    with m.Elif(done):
+                        # zero-length transaction
+                        m.next = "FINISH"
+                    with m.Elif(current_transaction_rw != tx.rw):
+                        # zero-length transaction
+                        m.next = "START"
+                    with m.Elif(current_transaction_rw == 1):
+                        m.next = "RD_RECV_VALUE"
+                    with m.Else():
+                        m.next = "WR_SEND_VALUE"
+
+            with m.State("RD_RECV_VALUE"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        self._transactions.r_en.eq(1),
+                        i2c.ack_i      .eq(1), # FIXME:  0 in last read byte
+                        i2c.read       .eq(1),
+                    ]
+                    m.next = "RD_WAIT_VALUE"
+
+            with m.State("RD_WAIT_VALUE"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        self._rx_fifo.w_data.eq(i2c.data_o),
+                        self._rx_fifo.w_en.eq(1),
+                    ]
+                    with m.If(done):
+                        m.next = "FINISH"
+                    with m.Elif(tx.rw != 1):
+                        m.next = "START"
+                    with m.Else():
+                        m.next = "RD_RECV_VALUE"
+
+            with m.State("WR_SEND_VALUE"):
+                with m.If(~i2c.busy):
+                    m.d.comb += [
+                        self._transactions.r_en.eq(1),
+                        i2c.data_i        .eq(tx.data),
+                        i2c.write         .eq(1),
+                    ]
+                    m.next = "WR_ACK_VALUE"
+
+            with m.State("WR_ACK_VALUE"):
+                with m.If(~i2c.busy):
+                    with m.If(~i2c.ack_o):
+                        m.next = "ABORT"
+                    with m.Elif(done):
+                        m.next = "FINISH"
+                    with m.Elif(tx.rw != 0):
+                        m.next = "START"
+                    with m.Else():
+                        m.next = "WR_SEND_VALUE"
+
+            with m.State("FINISH"):
+                with m.If(~i2c.busy):
+                    m.d.comb += i2c.stop.eq(1),
+                    m.next = "IDLE"
+
+            with m.State("ABORT"):
+                with m.If(~i2c.busy):
+                    m.d.sync += self.status.error.eq(1)
+                    m.d.comb += i2c.stop.eq(1)
+                    m.next = "DRAIN_FIFOS"
+
+            with m.State("DRAIN_FIFOS"):
+                with m.If((self._transactions.level == 0) &
+                          (self._rx_fifo.level == 0)):
+                    m.next = "IDLE"
+                with m.Else():
+                    m.d.comb += self._transactions.r_en.eq(1)
+                    m.d.comb += self._rx_fifo.r_en.eq(1)
+
         return m
 
 class Peripheral(wiring.Component):
@@ -74,14 +231,13 @@ class Peripheral(wiring.Component):
 
     CSR registers
     -------------
-    start : write-only
-        Write a '1' to execute all transactions in the transaction FIFO.
     address : write-only
         7-bit address of the target I2C device for the transactions.
     transaction : write-only
         Transaction FIFO. Each entry can be a write or read transaction.
         The 8 bit data words are the data to write (for write transactions),
-        or simply ignored (for read transactions).
+        or simply ignored (for read transactions). The 'last' bit denotes
+        the last entry in a transaction, and permits the core to start.
     rx_data : read-only
         Read FIFO. 8-bit entries, one per successful read transaction.
         This should only be read once 'busy' has deasserted.
@@ -89,9 +245,9 @@ class Peripheral(wiring.Component):
     -- status registers --
     busy : read-only
         If the core is currently executing transactions, '1', else '0'.
-    transaction_full : write-only
+    full : read-only
         If the transaction FIFO is full, '1', else '0'.
-    err : read
+    err :  read-only
         '1' if an error (e.g. NACK) has occurred.
         this flag is reset on a new set of transactions ('start' is set).
 
@@ -104,39 +260,28 @@ class Peripheral(wiring.Component):
       byte per the transaction() contract.
     """
 
-    class StartReg(csr.Register, access="w"):
-        start: csr.Field(csr.action.W, unsigned(1))
-
     class AddressReg(csr.Register, access="w"):
         address: csr.Field(csr.action.W, unsigned(7))
 
     class TransactionReg(csr.Register, access="w"):
-        rw:   csr.Field(csr.action.W, unsigned(1))
         data: csr.Field(csr.action.W, unsigned(8))
+        rw:   csr.Field(csr.action.W, unsigned(1))
+        last: csr.Field(csr.action.W, unsigned(1))
 
     class RxDataReg(csr.Register, access="r"):
         data: csr.Field(csr.action.R, unsigned(8))
 
     class StatusReg(csr.Register, access="r"):
-        busy:             csr.Field(csr.action.R, unsigned(1))
-        transaction_full: csr.Field(csr.action.R, unsigned(1))
-        error:            csr.Field(csr.action.R, unsigned(1))
+        busy:  csr.Field(csr.action.R, unsigned(1))
+        full:  csr.Field(csr.action.R, unsigned(1))
+        error: csr.Field(csr.action.R, unsigned(1))
 
-    def __init__(self, *, period_cyc, clk_stretch=False,
-                 transaction_depth=32, rx_depth=8, **kwargs):
-        self.period_cyc = period_cyc
-        self.clk_stretch = clk_stretch
+    def __init__(self, **kwargs):
 
-        self.data_width = 8
-        self.addr_width = 7
-        self.transaction_width = self.data_width + 1
-
-        self._transactions = SyncFIFOBuffered(width=self.transaction_width, depth=transaction_depth)
-        self._rx_fifo = SyncFIFOBuffered(width=self.data_width, depth=rx_depth)
+        self.i2c_stream = I2CStreamer(**kwargs)
 
         regs = csr.Builder(addr_width=5, data_width=8)
 
-        self._start           = regs.add("start",           self.StartReg(),       offset=0x0)
         self._address         = regs.add("address",         self.AddressReg(),     offset=0x4)
         self._transaction_reg = regs.add("transaction_reg", self.TransactionReg(), offset=0x8)
         self._rx_data         = regs.add("rx_data",         self.RxDataReg(),      offset=0xC)
@@ -146,153 +291,36 @@ class Peripheral(wiring.Component):
 
         super().__init__({
             "bus": In(csr.Signature(addr_width=regs.addr_width, data_width=regs.data_width)),
-            "pins": Out(PinSignature()),
+            "pins": Out(I2CPinSignature()),
         })
         self.bus.memory_map = self._bridge.bus.memory_map
 
-        self.address = Signal(self.addr_width)
-        self.transaction_rw = Signal()
-        self.transaction_data = Signal(self.data_width)
-
     def elaborate(self, platform):
         m = Module()
+
         m.submodules.bridge = self._bridge
-        m.submodules.rx_fifo = self._rx_fifo
-        m.submodules.transactions = self._transactions
+        m.submodules.i2c_stream = self.i2c_stream
 
-        connect(m, flipped(self.bus), self._bridge.bus)
-
-        err = Signal()
+        wiring.connect(m, flipped(self.bus), self._bridge.bus)
+        wiring.connect(m, flipped(self.pins), self.i2c_stream.pins)
 
         with m.If(self._address.f.address.w_stb):
-            m.d.sync += self.address.eq(self._address.f.address.w_data)
-
-        m.d.comb += self._status.f.error.r_data.eq(err)
+            m.d.sync += self.i2c_stream.address.eq(self._address.f.address.w_data)
 
         m.d.comb += [
-            self._transactions.w_en.eq(self._transaction_reg.element.w_stb),
-            self._transactions.w_data.eq(Cat(self._transaction_reg.f.data.w_data,
-                                             self._transaction_reg.f.rw.w_data)),
-            self._status.f.transaction_full.r_data.eq(~self._transactions.w_rdy),
-            self._rx_data.f.data.r_data.eq(self._rx_fifo.r_data),
-            self._rx_fifo.r_en.eq(self._rx_data.element.r_stb),
-            self.transaction_rw.eq(self._transactions.r_data[8]),
-            self.transaction_data.eq(self._transactions.r_data[0:8]),
+            self._status.f.busy.r_data.eq(self.i2c_stream.status.busy),
+            self._status.f.full.r_data.eq(~self.i2c_stream.i.ready),
+            self._status.f.error.r_data.eq(self.i2c_stream.status.error),
+
+            self.i2c_stream.i.valid.eq(self._transaction_reg.element.w_stb),
+            self.i2c_stream.i.payload.last.eq(self._transaction_reg.f.last.w_data),
+            self.i2c_stream.i.payload.rw.eq(self._transaction_reg.f.rw.w_data),
+            self.i2c_stream.i.payload.data.eq(self._transaction_reg.f.data.w_data),
         ]
 
-        m.submodules.i2c = i2c = I2CInitiator(pads=self.pins, period_cyc=self.period_cyc, clk_stretch=self.clk_stretch)
         m.d.comb += [
-            i2c.start.eq(0),
-            i2c.write.eq(0),
-            i2c.read.eq(0),
-            i2c.stop.eq(0),
+            self._rx_data.f.data.r_data.eq(self.i2c_stream.o.payload),
+            self.i2c_stream.o.ready.eq(self._rx_data.element.r_stb),
         ]
-
-        current_transaction_rw = Signal()
-        transaction_stb = Signal()
-        last_transaction = Signal()
-
-        m.d.comb += self._transactions.r_en.eq(transaction_stb)
-        m.d.comb += last_transaction.eq(self._transactions.level == 0)
-
-        with m.FSM() as fsm:
-
-            # We're busy whenever we're not IDLE; indicate so.
-            m.d.comb += self._status.f.busy.r_data.eq(~fsm.ongoing('IDLE'))
-
-            with m.State('IDLE'):
-                with m.If(self._start.f.start.w_stb & self._start.f.start.w_data):
-                    m.next = 'START'
-
-            with m.State('START'):
-                m.d.sync += err.eq(0)
-                with m.If(~i2c.busy):
-                    m.d.comb += i2c.start.eq(1),
-                    m.next = 'SEND_DEV_ADDRESS'
-
-            with m.State("SEND_DEV_ADDRESS"):
-                with m.If(~i2c.busy):
-                    m.d.comb += [
-                        i2c.data_i     .eq((self.address << 1) | self.transaction_rw),
-                        i2c.write      .eq(1),
-                    ]
-                    m.d.sync += current_transaction_rw.eq(self.transaction_rw)
-                    m.next = "ACK_DEV_ADDRESS"
-
-            with m.State("ACK_DEV_ADDRESS"):
-                with m.If(~i2c.busy):
-                    with m.If(~i2c.ack_o):
-                        m.next = "ABORT"
-                    with m.Elif(last_transaction):
-                        # zero-length transaction
-                        m.next = "FINISH"
-                    with m.Elif(current_transaction_rw != self.transaction_rw):
-                        # zero-length transaction
-                        m.next = "START"
-                    with m.Elif(current_transaction_rw == 1):
-                        m.next = "RD_RECV_VALUE"
-                    with m.Else():
-                        m.next = "WR_SEND_VALUE"
-
-            with m.State("RD_RECV_VALUE"):
-                with m.If(~i2c.busy):
-                    m.d.comb += [
-                        transaction_stb.eq(1),
-                        i2c.ack_i      .eq(1), # FIXME:  0 in last read byte
-                        i2c.read       .eq(1),
-                    ]
-                    m.next = "RD_WAIT_VALUE"
-
-            with m.State("RD_WAIT_VALUE"):
-                with m.If(~i2c.busy):
-                    m.d.comb += [
-                        self._rx_fifo.w_data.eq(i2c.data_o),
-                        self._rx_fifo.w_en.eq(1),
-                    ]
-                    with m.If(last_transaction):
-                        m.next = "FINISH"
-                    with m.Elif(self.transaction_rw != 1):
-                        m.next = "START"
-                    with m.Else():
-                        m.next = "RD_RECV_VALUE"
-
-            with m.State("WR_SEND_VALUE"):
-                with m.If(~i2c.busy):
-                    m.d.comb += [
-                        transaction_stb.eq(1),
-                        i2c.data_i     .eq(self.transaction_data),
-                        i2c.write      .eq(1),
-                    ]
-                    m.next = "WR_ACK_VALUE"
-
-            with m.State("WR_ACK_VALUE"):
-                with m.If(~i2c.busy):
-                    with m.If(~i2c.ack_o):
-                        m.next = "ABORT"
-                    with m.Elif(last_transaction):
-                        m.next = "FINISH"
-                    with m.Elif(self.transaction_rw != 0):
-                        m.next = "START"
-                    with m.Else():
-                        m.next = "WR_SEND_VALUE"
-
-            with m.State("FINISH"):
-                with m.If(~i2c.busy):
-                    m.d.comb += i2c.stop.eq(1),
-                    m.next = "IDLE"
-
-            with m.State("ABORT"):
-                with m.If(~i2c.busy):
-                    m.d.sync += err.eq(1)
-                    m.d.comb += i2c.stop.eq(1)
-                    m.next = "DRAIN_FIFOS"
-
-            with m.State("DRAIN_FIFOS"):
-                with m.If((self._transactions.level == 0) &
-                          (self._rx_fifo.level == 0)):
-                    m.next = "IDLE"
-                with m.Else():
-                    m.d.comb += self._transactions.r_en.eq(1)
-                    m.d.comb += self._rx_fifo.r_en.eq(1)
 
         return m

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -188,7 +188,7 @@ class _TiliquaR2Mobo:
             Subsignal("lrck",    Pins("48", dir="o",  conn=("m2", 0))),
             Subsignal("bick",    Pins("50", dir="o",  conn=("m2", 0))),
             Subsignal("mclk",    Pins("52", dir="o",  conn=("m2", 0))),
-            Subsignal("pdn",     Pins("54", dir="o",  conn=("m2", 0))),
+            Subsignal("pdn_d",   Pins("54", dir="o",  conn=("m2", 0))),
             Subsignal("i2c_sda", Pins("56", dir="io", conn=("m2", 0))),
             Subsignal("i2c_scl", Pins("58", dir="io", conn=("m2", 0))),
             Attrs(IO_TYPE="LVCMOS33")
@@ -262,7 +262,8 @@ class _TiliquaR3Mobo:
             Subsignal("lrck",    Pins("48", dir="o",  conn=("m2", 0))),
             Subsignal("bick",    Pins("50", dir="o",  conn=("m2", 0))),
             Subsignal("mclk",    Pins("67", dir="o",  conn=("m2", 0))),
-            Subsignal("pdn",     Pins("65", dir="o",  conn=("m2", 0))),
+            Subsignal("pdn_d",   Pins("65", dir="o",  conn=("m2", 0))),
+            Subsignal("pdn_clk", Pins("56", dir="o",  conn=("m2", 0))),
             Subsignal("i2c_sda", Pins("71", dir="io", conn=("m2", 0))),
             Subsignal("i2c_scl", Pins("69", dir="io", conn=("m2", 0))),
             Attrs(IO_TYPE="LVCMOS33")

--- a/gateware/src/tiliqua/tiliqua_platform.py
+++ b/gateware/src/tiliqua/tiliqua_platform.py
@@ -359,11 +359,12 @@ class RebootProvider(wiring.Component):
         assert(timeout_reboot > (timeout_mute - 0.25))
         button_counter = Signal(range(timeout_reboot+1))
         with m.If(button_counter >= timeout_mute):
-            m.d.comb += self.mute.eq(1)
+            m.d.sync += self.mute.eq(1)
         with m.If(button_counter >= timeout_reboot):
             m.d.comb += platform.request("self_program").o.eq(1)
         with m.Else():
-            with m.If(self.button):
+            # we already started muting. point of no return.
+            with m.If(self.button | self.mute):
                 m.d.sync += button_counter.eq(button_counter + 1)
             with m.Else():
                 m.d.sync += button_counter.eq(0)

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -377,6 +377,8 @@ class TiliquaSoc(Component):
             self.pmod0_periph.pmod = pmod0
             m.submodules.pmod0_periph = self.pmod0_periph
 
+            m.d.comb += pmod0.codec_mute.eq(self.encoder0._button.f.button.r_data)
+
             # die temperature
             m.submodules.dtr0 = self.dtr0
 

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -390,7 +390,7 @@ class TiliquaSoc(Component):
             # Connect encoder button to RebootProvider
             m.submodules.reboot = reboot = RebootProvider(car.clocks_hz["sync"])
             m.d.comb += reboot.button.eq(self.encoder0._button.f.button.r_data)
-            m.d.comb += pmod0.codec_mute.eq(reboot.mute)
+            m.d.comb += self.pmod0_periph.mute.eq(reboot.mute)
         else:
             m.submodules.car = sim.FakeTiliquaDomainGenerator()
             self.pmod0_periph.pmod = sim.FakeEurorackPmod()

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -390,6 +390,7 @@ class TiliquaSoc(Component):
             # Connect encoder button to RebootProvider
             m.submodules.reboot = reboot = RebootProvider(car.clocks_hz["sync"])
             m.d.comb += reboot.button.eq(self.encoder0._button.f.button.r_data)
+            m.d.comb += pmod0.codec_mute.eq(reboot.mute)
         else:
             m.submodules.car = sim.FakeTiliquaDomainGenerator()
             self.pmod0_periph.pmod = sim.FakeEurorackPmod()

--- a/gateware/src/tiliqua/tiliqua_soc.py
+++ b/gateware/src/tiliqua/tiliqua_soc.py
@@ -377,8 +377,6 @@ class TiliquaSoc(Component):
             self.pmod0_periph.pmod = pmod0
             m.submodules.pmod0_periph = self.pmod0_periph
 
-            m.d.comb += pmod0.codec_mute.eq(self.encoder0._button.f.button.r_data)
-
             # die temperature
             m.submodules.dtr0 = self.dtr0
 

--- a/gateware/src/top/bootloader/fw/src/main.rs
+++ b/gateware/src/top/bootloader/fw/src/main.rs
@@ -86,6 +86,7 @@ fn timer0_handler(app: &Mutex<RefCell<App>>) {
 #[entry]
 fn main() -> ! {
     let peripherals = pac::Peripherals::take().unwrap();
+    let pmod = peripherals.PMOD0_PERIPH;
 
     let sysclk = pac::clock::sysclk();
     let serial = Serial0::new(peripherals.UART0);
@@ -141,6 +142,7 @@ fn main() -> ! {
 
             if opts.modify() {
                 if let Some(n) = opts.view().selected() {
+                    pmod.flags().write(|w|  w.mute().bit(true) );
                     print_rebooting(&mut display, &mut rng);
                     // TODO: delay before reboot.
                     info!("BITSTREAM{}\n\r", n);

--- a/gateware/src/top/dsp/top.py
+++ b/gateware/src/top/dsp/top.py
@@ -816,6 +816,7 @@ class CoreTop(Elaboratable):
             m.submodules.reboot = reboot = RebootProvider(car.clocks_hz["sync"])
             m.submodules.btn = FFSynchronizer(
                     platform.request("encoder").s.i, reboot.button)
+            m.d.comb += pmod0.codec_mute.eq(reboot.mute)
         else:
             m.submodules.car = sim.FakeTiliquaDomainGenerator()
             m.submodules.pmod0 = pmod0 = sim.FakeEurorackPmod()

--- a/gateware/src/top/selftest/fw/src/main.rs
+++ b/gateware/src/top/selftest/fw/src/main.rs
@@ -182,8 +182,9 @@ fn print_touch_state<D>(d: &mut D, pmod: &pac::PMOD0_PERIPH)
 where
     D: DrawTarget<Color = Gray8>,
 {
-    let mut s = String::<64>::new();
-    write!(s, "touch          - ch0={:03} ch1={:03} ch2={:03} ch3={:03} ch4={:03} ch5={:03} ch6={:03} ch7={:03}",
+    let mut s = String::<128>::new();
+    write!(s, "touch          - err={:03} ch0={:03} ch1={:03} ch2={:03} ch3={:03} ch4={:03} ch5={:03} ch6={:03} ch7={:03}",
+          pmod.touch_err().read().bits() as u8,
           pmod.touch0().read().bits() as u8,
           pmod.touch1().read().bits() as u8,
           pmod.touch2().read().bits() as u8,

--- a/gateware/src/top/selftest/fw/src/main.rs
+++ b/gateware/src/top/selftest/fw/src/main.rs
@@ -203,6 +203,24 @@ where
     .draw(d).ok();
 }
 
+fn print_jack_state<D>(d: &mut D, pmod: &pac::PMOD0_PERIPH)
+where
+    D: DrawTarget<Color = Gray8>,
+{
+    let mut s = String::<64>::new();
+    write!(s, "jack           - 0x{:x}",
+          pmod.jack().read().bits() as u8).ok();
+    info!("{}", s);
+    let style = MonoTextStyle::new(&FONT_6X10, Gray8::WHITE);
+    Text::with_alignment(
+        &s,
+        d.bounding_box().center() + Point::new(-140, 12),
+        style,
+        Alignment::Left,
+    )
+    .draw(d).ok();
+}
+
 fn print_usb_state<D>(d: &mut D, i2cdev: &mut I2c0)
 where
     D: DrawTarget<Color = Gray8>,
@@ -228,7 +246,7 @@ where
     let style = MonoTextStyle::new(&FONT_6X10, Gray8::WHITE);
     Text::with_alignment(
         &s,
-        d.bounding_box().center() + Point::new(-140, 12),
+        d.bounding_box().center() + Point::new(-140, 24),
         style,
         Alignment::Left,
     )
@@ -260,7 +278,7 @@ where
     let style = MonoTextStyle::new(&FONT_6X10, Gray8::WHITE);
     Text::with_alignment(
         &s,
-        d.bounding_box().center() + Point::new(-140, 24),
+        d.bounding_box().center() + Point::new(-140, 36),
         style,
         Alignment::Left,
     )
@@ -352,6 +370,9 @@ fn main() -> ! {
         pause_flush(&mut timer, &mut uptime_ms, period_ms);
 
         print_touch_state(&mut display, &pmod);
+        pause_flush(&mut timer, &mut uptime_ms, period_ms);
+
+        print_jack_state(&mut display, &pmod);
         pause_flush(&mut timer, &mut uptime_ms, period_ms);
 
         print_usb_state(&mut display, &mut i2cdev);

--- a/gateware/src/top/usb_audio/top.py
+++ b/gateware/src/top/usb_audio/top.py
@@ -486,6 +486,7 @@ class USB2AudioInterface(Elaboratable):
         m.submodules.pmod0 = pmod0 = EurorackPmod(
                 pmod_pins=platform.request("audio_ffc"),
                 hardware_r33=True)
+        m.d.comb += pmod0.codec_mute.eq(reboot.mute)
 
         m.submodules.audio_to_channels = AudioToChannels(
                 pmod0,

--- a/gateware/src/top/usb_host/top.py
+++ b/gateware/src/top/usb_host/top.py
@@ -76,6 +76,8 @@ class USB2HostTest(Elaboratable):
                 pmod_pins=platform.request("audio_ffc"),
                 hardware_r33=True,
                 touch_enabled=False)
+        m.d.comb += pmod0.codec_mute.eq(reboot.mute)
+
 
         m.submodules.audio_stream = audio_stream = eurorack_pmod.AudioStream(pmod0)
         m.submodules.midi_cv = self.midi_cv = midi.MonoMidiCV()

--- a/gateware/src/top/vectorscope_no_soc/top.py
+++ b/gateware/src/top/vectorscope_no_soc/top.py
@@ -111,6 +111,7 @@ class VectorScopeTop(Elaboratable):
             m.submodules.reboot = reboot = RebootProvider(car.clocks_hz["sync"])
             m.submodules.btn = FFSynchronizer(
                     platform.request("encoder").s.i, reboot.button)
+            m.d.comb += self.pmod0.codec_mute.eq(reboot.mute)
 
         if sim.is_hw(platform):
             self.pmod0 = eurorack_pmod.EurorackPmod(

--- a/gateware/src/top/vectorscope_no_soc/top.py
+++ b/gateware/src/top/vectorscope_no_soc/top.py
@@ -111,7 +111,6 @@ class VectorScopeTop(Elaboratable):
             m.submodules.reboot = reboot = RebootProvider(car.clocks_hz["sync"])
             m.submodules.btn = FFSynchronizer(
                     platform.request("encoder").s.i, reboot.button)
-            m.d.comb += self.pmod0.codec_mute.eq(reboot.mute)
 
         if sim.is_hw(platform):
             self.pmod0 = eurorack_pmod.EurorackPmod(
@@ -119,6 +118,7 @@ class VectorScopeTop(Elaboratable):
                 hardware_r33=True,
                 touch_enabled=False,
                 audio_192=True)
+            m.d.comb += self.pmod0.codec_mute.eq(reboot.mute)
 
         pmod0 = self.pmod0
         m.submodules.pmod0 = pmod0

--- a/gateware/tests/test_i2c.py
+++ b/gateware/tests/test_i2c.py
@@ -12,29 +12,20 @@ from tiliqua               import i2c, test_util
 from amaranth_soc          import csr
 from amaranth_soc.csr      import wishbone
 
+from vendor                import i2c as vendor_i2c
+
 class I2CTests(unittest.TestCase):
 
-    def test_i2c_tx(self):
-
-        class FakeTristate:
-            i  = Signal()
-            o  = Signal()
-            oe = Signal()
-
-        class FakeI2CPads:
-            sda = FakeTristate()
-            scl = FakeTristate()
-
-        i2c_pads = FakeI2CPads()
+    def test_i2c_peripheral(self):
 
         m = Module()
-        dut = i2c.Peripheral(pads=i2c_pads, period_cyc=4)
+        dut = i2c.Peripheral(period_cyc=4)
         decoder = csr.Decoder(addr_width=28, data_width=8)
         decoder.add(dut.bus, addr=0, name="dut")
         bridge = wishbone.WishboneCSRBridge(decoder.bus, data_width=32)
         m.submodules += [dut, decoder, bridge]
 
-        async def testbench(ctx):
+        async def test_stimulus(ctx):
 
             async def csr_write(ctx, value, register, field=None):
                 await test_util.wb_csr_w(
@@ -51,29 +42,86 @@ class I2CTests(unittest.TestCase):
             await csr_write(ctx, 0x042, "transaction_reg")
             await csr_write(ctx, 0x013, "transaction_reg")
 
-            # enqueue 1x read op
-            await csr_write(ctx, 0x100, "transaction_reg")
+            # enqueue 1x read + last op
+            await csr_write(ctx, 0x300, "transaction_reg")
 
             # 3 transactions are enqueued
-            self.assertEqual(ctx.get(dut._transactions.level), 3)
-
-            # start the i2c core
-            await csr_write(ctx,     1, "start")
+            self.assertEqual(ctx.get(dut.i2c_stream._transactions.level), 3)
 
             # busy flag should go high
             self.assertEqual(await csr_read(ctx, "status", "busy"), 1)
 
-            # run for a while
             await ctx.tick().repeat(500)
 
             # busy flag should be low
             self.assertEqual(await csr_read(ctx, "status", "busy"), 0)
 
             # all transactions drained.
-            self.assertEqual(ctx.get(dut._transactions.level), 0)
+            self.assertEqual(ctx.get(dut.i2c_stream._transactions.level), 0)
+
+        async def test_response(ctx):
+
+            was_busy = False
+            data_written = []
+            while True:
+                await ctx.tick()
+                if ctx.get(dut.i2c_stream.status.busy) and not was_busy:
+                    was_busy = True
+                if was_busy and not ctx.get(dut.i2c_stream.status.busy):
+                    break
+                if ctx.get(dut.i2c_stream.i2c.start):
+                    print("i2c.start")
+                if ctx.get(dut.i2c_stream.i2c.write):
+                    v = ctx.get(dut.i2c_stream.i2c.data_i)
+                    print("i2c.write", hex(v))
+                    data_written.append(v)
+                if ctx.get(dut.i2c_stream.i2c.read):
+                    print("i2c.read",  hex(ctx.get(dut.i2c_stream.i2c.data_o)))
+                if ctx.get(dut.i2c_stream.i2c.stop):
+                    print("i2c.stop")
+
+            self.assertEqual(data_written, [0xaa, 0x42, 0x13, 0xab])
+
+        sim = Simulator(m)
+        sim.add_clock(1e-6)
+        sim.add_testbench(test_stimulus)
+        sim.add_testbench(test_response, background=True)
+        with sim.write_vcd(vcd_file=open("test_i2c_peripheral.vcd", "w")):
+            sim.run()
+
+    def test_i2c_luna_register_interface(self):
+
+        m = Module()
+        dut = vendor_i2c.I2CRegisterInterface(period_cyc=4, max_data_bytes=16)
+        m.submodules += [dut]
+
+        async def testbench(ctx):
+            ctx.set(dut.dev_address,   0x5)
+            ctx.set(dut.reg_address,   0x42)
+            ctx.set(dut.size,          4)
+            ctx.set(dut.write_request, 1)
+            ctx.set(dut.write_data[-32:], 0xDEADBEEF)
+            await ctx.tick()
+            ctx.set(dut.write_request, 0)
+            data_written = []
+            print()
+            while ctx.get(dut.busy):
+                if ctx.get(dut.i2c.start):
+                    print("i2c.start")
+                if ctx.get(dut.i2c.write):
+                    v = ctx.get(dut.i2c.data_i)
+                    print("i2c.write", hex(v))
+                    data_written.append(v)
+                if ctx.get(dut.i2c.read):
+                    print("i2c.read",  hex(ctx.get(dut.i2c.data_o)))
+                if ctx.get(dut.i2c.stop):
+                    print("i2c.stop")
+                await ctx.tick()
+
+            self.assertEqual(data_written, [0xa, 0x42, 0xde, 0xad, 0xbe, 0xef])
 
         sim = Simulator(m)
         sim.add_clock(1e-6)
         sim.add_testbench(testbench)
-        with sim.write_vcd(vcd_file=open("test_i2c_tx.vcd", "w")):
+        with sim.write_vcd(vcd_file=open("test_i2c_luna_register_interface.vcd", "w")):
             sim.run()

--- a/gateware/tests/test_i2c.py
+++ b/gateware/tests/test_i2c.py
@@ -6,7 +6,8 @@ import unittest
 
 from amaranth              import *
 from amaranth.sim          import *
-from amaranth.lib          import wiring
+from amaranth.lib          import wiring, data
+from amaranth.lib.memory   import Memory
 from tiliqua               import i2c, test_util
 
 from amaranth_soc          import csr
@@ -16,15 +17,76 @@ from vendor                import i2c as vendor_i2c
 
 class PmodMaster(wiring.Component):
 
+    PCA9557_ADDR     = 0x18
+    PCA9635_ADDR     = 0x5
+    AK4619VN_ADDR    = 0x10
+    CY8CMBR3108_ADDR = 0x37
+
+    N_JACKS   = 8
+    N_LEDS    = N_JACKS * 2
+    N_SENSORS = 8
+
+    PCA9635_CFG = [
+        0x80, # Auto-increment starting from MODE1
+        0x81, # MODE1
+        0x01, # MODE2
+        0x10, # PWM0
+        0x10, # PWM1
+        0x10, # PWM2
+        0x10, # PWM3
+        0x10, # PWM4
+        0x10, # PWM5
+        0x10, # PWM6
+        0x10, # PWM7
+        0x10, # PWM8
+        0x10, # PWM9
+        0x10, # PWM10
+        0x10, # PWM11
+        0x10, # PWM12
+        0x10, # PWM13
+        0x10, # PWM14
+        0x10, # PWM15
+        0xFF, # GRPPWM
+        0x00, # GRPFREQ
+        0xAA, # LEDOUT0
+        0xAA, # LEDOUT1
+        0xAA, # LEDOUT2
+        0xAA, # LEDOUT3
+    ]
+
+    AK4619VN_CFG = [
+        0x00, # Register address to start at.
+        0x37, # 0x00 Power Management
+        0xAE, # 0x01 Audio I/F Format
+        0x1C, # 0x02 Audio I/F Format
+        0x00, # 0x03 System Clock Setting
+        0x22, # 0x04 MIC AMP Gain
+        0x22, # 0x05 MIC AMP Gain
+        0x30, # 0x06 ADC1 Lch Digital Volume
+        0x30, # 0x07 ADC1 Rch Digital Volume
+        0x30, # 0x08 ADC2 Lch Digital Volume
+        0x30, # 0x09 ADC2 Rch Digital Volume
+        0x22, # 0x0A ADC Digital Filter Setting
+        0x55, # 0x0B ADC Analog Input Setting
+        0x00, # 0x0C Reserved
+        0x06, # 0x0D ADC Mute & HPF Control
+        0x18, # 0x0E DAC1 Lch Digital Volume
+        0x18, # 0x0F DAC1 Rch Digital Volume
+        0x18, # 0x10 DAC2 Lch Digital Volume
+        0x18, # 0x11 DAC2 Rch Digital Volume
+        0x04, # 0x12 DAC Input Select Setting
+        0x05, # 0x13 DAC De-Emphasis Setting
+        0x0A, # 0x14 DAC Mute & Filter Setting
+    ]
+
     def __init__(self):
         self.i2c_stream = i2c.I2CStreamer(period_cyc=4)
         super().__init__({
-            "pins": Out(I2CPinSignature()),
-
-            "jack": Out(8)
+            "pins": wiring.Out(vendor_i2c.I2CPinSignature()),
+            "jack":   wiring.Out(self.N_JACKS),
+            "led":    wiring.In(signed(8)).array(self.N_JACKS),
+            "touch":  wiring.Out(unsigned(8)).array(self.N_SENSORS),
         })
-
-
 
     def elaborate(self, platform):
         m = Module()
@@ -32,24 +94,165 @@ class PmodMaster(wiring.Component):
         m.submodules.i2c_stream = i2c = self.i2c_stream
         wiring.connect(m, wiring.flipped(self.pins), self.i2c_stream.pins)
 
+        def state_id(ix):
+            return (f"i2c_state{ix}", f"i2c_state{ix+1}", ix+1)
 
-        with m.FSM() as fsm:
-            with m.State('JACK-INVERSION-REG'):
-                m.d.sync += [
-                    i2c.address.eq(0x18),
+        def i2c_addr(m, ix, addr):
+            cur, nxt, ix = state_id(ix)
+            with m.State(cur):
+                m.d.sync += i2c.address.eq(addr),
+                m.next = nxt
+            return cur, nxt, ix
+
+        def i2c_write(m, ix, data, last=False):
+            cur, nxt, ix = state_id(ix)
+            with m.State(cur):
+                m.d.comb += [
                     i2c.i.valid.eq(1),
                     i2c.i.payload.rw.eq(0), # Write
-                    i2c.i.payload.data.eq(0x02),
+                    i2c.i.payload.data.eq(data),
+                    i2c.i.payload.last.eq(1 if last else 0),
                 ]
-                m.next = 'JACK-INVERSION-REG-VALUE'
-            with m.State('JACK-INVERSION-REG-VALUE'):
-                m.d.sync += [
-                    i2c.address.eq(0x18),
+                m.next = nxt
+            return cur, nxt, ix
+
+        def i2c_w_arr(m, ix, data):
+            cur, nxt, ix = state_id(ix)
+            with m.State(cur):
+                cnt = Signal(range(len(data)+2))
+                mem = Memory(
+                    shape=unsigned(8), depth=len(data), init=data)
+                m.submodules += mem
+                rd_port = mem.read_port()
+                m.d.comb += [
+                    rd_port.en.eq(1),
+                    rd_port.addr.eq(cnt),
+                ]
+                with m.If(cnt != len(data) + 1):
+                    m.d.sync += cnt.eq(cnt+1)
+                    m.d.comb += [
+                        i2c.i.valid.eq(1),
+                        i2c.i.payload.rw.eq(0), # Write
+                        i2c.i.payload.data.eq(rd_port.data),
+                        i2c.i.payload.last.eq(cnt == (len(data)-1)),
+                    ]
+                with m.Else():
+                    m.d.sync += cnt.eq(0)
+                    m.next = nxt
+            return cur, nxt, ix
+
+        def i2c_read(m, ix, last=False):
+            cur, nxt, ix = state_id(ix)
+            with m.State(cur):
+                m.d.comb += [
                     i2c.i.valid.eq(1),
-                    i2c.i.payload.rw  .eq(0), # Write
-                    i2c.i.payload.data.eq(0x00),
-                    i2c.i.payload.last.eq(1),
+                    i2c.i.payload.rw.eq(1), # Read
+                    i2c.i.payload.last.eq(1 if last else 0),
                 ]
+                m.next = nxt
+            return cur, nxt, ix
+
+        def i2c_wait(m, ix):
+            cur,  nxt, ix = state_id(ix)
+            with m.State(cur):
+                with m.If(~i2c.status.busy):
+                    m.next = nxt
+            return cur, nxt, ix
+
+
+        # used for implicit state machine ID tracking / generation
+        ix = 0
+
+        led_reg = Signal(data.ArrayLayout(unsigned(8), self.N_LEDS))
+        for n in range(self.N_LEDS):
+            if n % 2 == 0:
+                with m.If(self.led[n//2] > 0):
+                    m.d.comb += led_reg[n].eq(0)
+                with m.Else():
+                    m.d.comb += led_reg[n].eq(-self.led[n//2])
+            else:
+                with m.If(self.led[n//2] > 0):
+                    m.d.comb += led_reg[n].eq(self.led[n//2])
+                with m.Else():
+                    m.d.comb += led_reg[n].eq(0)
+
+        touch_nsensor = Signal(range(self.N_SENSORS))
+
+        with m.FSM() as fsm:
+
+            #
+            # PCA9557 init
+            #
+
+            cur, _,   ix  = i2c_addr (m, ix, self.PCA9557_ADDR)
+            _,   _,   ix  = i2c_write(m, ix, 0x02)
+            _,   _,   ix  = i2c_write(m, ix, 0x00, last=True)
+            _,   _,   ix  = i2c_wait (m, ix) # set polarity inversion reg
+
+            #
+            # PCA9635 init
+            #
+            _,   _,   ix  = i2c_addr (m, ix, self.PCA9635_ADDR)
+            _,   _,   ix  = i2c_w_arr(m, ix, self.PCA9635_CFG)
+            _,   _,   ix  = i2c_wait (m, ix)
+
+            #
+            # AK4619VN init
+            #
+            _,   _,   ix  = i2c_addr (m, ix, self.AK4619VN_ADDR)
+            _,   _,   ix  = i2c_w_arr(m, ix, self.AK4619VN_CFG)
+            _,   _,   ix  = i2c_wait (m, ix)
+
+            #
+            # BEGIN MAIN LOOP
+            #
+
+            #
+            # PCA9635 update (LED brightnesses)
+            #
+            cur, _,   ix  = i2c_addr (m, ix, self.PCA9635_ADDR)
+            _,   _,   ix  = i2c_write(m, ix, 0x82) # start from first brightness reg
+            for n in range(self.N_LEDS):
+                _,   _,   ix  = i2c_write(m, ix, led_reg[n], last=(n==self.N_LEDS-1))
+            _,   _,   ix  = i2c_wait (m, ix)
+
+            s_loop_begin = cur
+
+            #
+            # CY8CMBR3108 read (Touch scan registers)
+            #
+
+            _,   _,   ix  = i2c_addr (m, ix, self.CY8CMBR3108_ADDR)
+            _,   _,   ix  = i2c_write(m, ix, 0xBA + (touch_nsensor<<1))
+            _,   _,   ix  = i2c_read (m, ix, last=True)
+            _,   _,   ix  = i2c_wait (m, ix)
+
+            # Latch valid reads to dedicated touch register.
+            cur, nxt, ix = state_id(ix)
+            with m.State(cur):
+                m.d.sync += touch_nsensor.eq(touch_nsensor+1)
+                with m.If(~i2c.status.error):
+                    with m.Switch(touch_nsensor):
+                        for n in range(8):
+                            m.d.sync += self.touch[n].eq(i2c.o.payload)
+                    m.d.comb += i2c.o.ready.eq(1)
+                m.next = nxt
+
+            #
+            # PCA9557 read (Jack input port register)
+            #
+            _,   _,   ix  = i2c_addr (m, ix, self.PCA9557_ADDR)
+            _,   _,   ix  = i2c_write(m, ix, 0x00)
+            _,   _,   ix  = i2c_read (m, ix, last=True)
+            _,   nxt, ix  = i2c_wait (m, ix)
+
+            # Latch valid reads to dedicated jack register.
+            with m.State(nxt):
+                with m.If(~i2c.status.error):
+                    m.d.sync += self.jack.eq(i2c.o.payload)
+                    m.d.comb += i2c.o.ready.eq(1)
+                # Go back to LED brightness update
+                m.next = s_loop_begin
 
         return m
 
@@ -125,6 +328,42 @@ class I2CTests(unittest.TestCase):
         sim.add_clock(1e-6)
         sim.add_testbench(test_stimulus)
         sim.add_testbench(test_response, background=True)
+        with sim.write_vcd(vcd_file=open("test_i2c_peripheral.vcd", "w")):
+            sim.run()
+
+    def test_i2c_master(self):
+
+        m = Module()
+        dut = PmodMaster()
+        m.submodules += [dut]
+
+        async def test_response(ctx):
+            was_busy = False
+            data_written = []
+            ctx.set(dut.led[0], -10)
+            ctx.set(dut.led[1], 10)
+            while True:
+                await ctx.tick()
+                """
+                if ctx.get(dut.i2c_stream.status.busy) and not was_busy:
+                    was_busy = True
+                if was_busy and not ctx.get(dut.i2c_stream.status.busy):
+                    break
+                """
+                if ctx.get(dut.i2c_stream.i2c.start):
+                    print("i2c.start")
+                if ctx.get(dut.i2c_stream.i2c.write):
+                    v = ctx.get(dut.i2c_stream.i2c.data_i)
+                    print("i2c.write", hex(v))
+                    data_written.append(v)
+                if ctx.get(dut.i2c_stream.i2c.read):
+                    print("i2c.read",  hex(ctx.get(dut.i2c_stream.i2c.data_o)))
+                if ctx.get(dut.i2c_stream.i2c.stop):
+                    print("i2c.stop")
+
+        sim = Simulator(m)
+        sim.add_clock(1e-6)
+        sim.add_testbench(test_response)
         with sim.write_vcd(vcd_file=open("test_i2c_peripheral.vcd", "w")):
             sim.run()
 

--- a/gateware/tests/test_i2c.py
+++ b/gateware/tests/test_i2c.py
@@ -8,253 +8,11 @@ from amaranth              import *
 from amaranth.sim          import *
 from amaranth.lib          import wiring, data
 from amaranth.lib.memory   import Memory
-from tiliqua               import i2c, test_util
+from tiliqua               import i2c, test_util, eurorack_pmod
+from vendor                import i2c as vendor_i2c
 
 from amaranth_soc          import csr
 from amaranth_soc.csr      import wishbone
-
-from vendor                import i2c as vendor_i2c
-
-class PmodMaster(wiring.Component):
-
-    PCA9557_ADDR     = 0x18
-    PCA9635_ADDR     = 0x5
-    AK4619VN_ADDR    = 0x10
-    CY8CMBR3108_ADDR = 0x37
-
-    N_JACKS   = 8
-    N_LEDS    = N_JACKS * 2
-    N_SENSORS = 8
-
-    PCA9635_CFG = [
-        0x80, # Auto-increment starting from MODE1
-        0x81, # MODE1
-        0x01, # MODE2
-        0x10, # PWM0
-        0x10, # PWM1
-        0x10, # PWM2
-        0x10, # PWM3
-        0x10, # PWM4
-        0x10, # PWM5
-        0x10, # PWM6
-        0x10, # PWM7
-        0x10, # PWM8
-        0x10, # PWM9
-        0x10, # PWM10
-        0x10, # PWM11
-        0x10, # PWM12
-        0x10, # PWM13
-        0x10, # PWM14
-        0x10, # PWM15
-        0xFF, # GRPPWM
-        0x00, # GRPFREQ
-        0xAA, # LEDOUT0
-        0xAA, # LEDOUT1
-        0xAA, # LEDOUT2
-        0xAA, # LEDOUT3
-    ]
-
-    AK4619VN_CFG = [
-        0x00, # Register address to start at.
-        0x37, # 0x00 Power Management
-        0xAE, # 0x01 Audio I/F Format
-        0x1C, # 0x02 Audio I/F Format
-        0x00, # 0x03 System Clock Setting
-        0x22, # 0x04 MIC AMP Gain
-        0x22, # 0x05 MIC AMP Gain
-        0x30, # 0x06 ADC1 Lch Digital Volume
-        0x30, # 0x07 ADC1 Rch Digital Volume
-        0x30, # 0x08 ADC2 Lch Digital Volume
-        0x30, # 0x09 ADC2 Rch Digital Volume
-        0x22, # 0x0A ADC Digital Filter Setting
-        0x55, # 0x0B ADC Analog Input Setting
-        0x00, # 0x0C Reserved
-        0x06, # 0x0D ADC Mute & HPF Control
-        0x18, # 0x0E DAC1 Lch Digital Volume
-        0x18, # 0x0F DAC1 Rch Digital Volume
-        0x18, # 0x10 DAC2 Lch Digital Volume
-        0x18, # 0x11 DAC2 Rch Digital Volume
-        0x04, # 0x12 DAC Input Select Setting
-        0x05, # 0x13 DAC De-Emphasis Setting
-        0x0A, # 0x14 DAC Mute & Filter Setting
-    ]
-
-    def __init__(self):
-        self.i2c_stream = i2c.I2CStreamer(period_cyc=4)
-        super().__init__({
-            "pins": wiring.Out(vendor_i2c.I2CPinSignature()),
-            "jack":   wiring.Out(self.N_JACKS),
-            "led":    wiring.In(signed(8)).array(self.N_JACKS),
-            "touch":  wiring.Out(unsigned(8)).array(self.N_SENSORS),
-        })
-
-    def elaborate(self, platform):
-        m = Module()
-
-        m.submodules.i2c_stream = i2c = self.i2c_stream
-        wiring.connect(m, wiring.flipped(self.pins), self.i2c_stream.pins)
-
-        def state_id(ix):
-            return (f"i2c_state{ix}", f"i2c_state{ix+1}", ix+1)
-
-        def i2c_addr(m, ix, addr):
-            cur, nxt, ix = state_id(ix)
-            with m.State(cur):
-                m.d.sync += i2c.address.eq(addr),
-                m.next = nxt
-            return cur, nxt, ix
-
-        def i2c_write(m, ix, data, last=False):
-            cur, nxt, ix = state_id(ix)
-            with m.State(cur):
-                m.d.comb += [
-                    i2c.i.valid.eq(1),
-                    i2c.i.payload.rw.eq(0), # Write
-                    i2c.i.payload.data.eq(data),
-                    i2c.i.payload.last.eq(1 if last else 0),
-                ]
-                m.next = nxt
-            return cur, nxt, ix
-
-        def i2c_w_arr(m, ix, data):
-            cur, nxt, ix = state_id(ix)
-            with m.State(cur):
-                cnt = Signal(range(len(data)+2))
-                mem = Memory(
-                    shape=unsigned(8), depth=len(data), init=data)
-                m.submodules += mem
-                rd_port = mem.read_port()
-                m.d.comb += [
-                    rd_port.en.eq(1),
-                    rd_port.addr.eq(cnt),
-                ]
-                with m.If(cnt != len(data) + 1):
-                    m.d.sync += cnt.eq(cnt+1)
-                    m.d.comb += [
-                        i2c.i.valid.eq(1),
-                        i2c.i.payload.rw.eq(0), # Write
-                        i2c.i.payload.data.eq(rd_port.data),
-                        i2c.i.payload.last.eq(cnt == (len(data)-1)),
-                    ]
-                with m.Else():
-                    m.d.sync += cnt.eq(0)
-                    m.next = nxt
-            return cur, nxt, ix
-
-        def i2c_read(m, ix, last=False):
-            cur, nxt, ix = state_id(ix)
-            with m.State(cur):
-                m.d.comb += [
-                    i2c.i.valid.eq(1),
-                    i2c.i.payload.rw.eq(1), # Read
-                    i2c.i.payload.last.eq(1 if last else 0),
-                ]
-                m.next = nxt
-            return cur, nxt, ix
-
-        def i2c_wait(m, ix):
-            cur,  nxt, ix = state_id(ix)
-            with m.State(cur):
-                with m.If(~i2c.status.busy):
-                    m.next = nxt
-            return cur, nxt, ix
-
-
-        # used for implicit state machine ID tracking / generation
-        ix = 0
-
-        led_reg = Signal(data.ArrayLayout(unsigned(8), self.N_LEDS))
-        for n in range(self.N_LEDS):
-            if n % 2 == 0:
-                with m.If(self.led[n//2] > 0):
-                    m.d.comb += led_reg[n].eq(0)
-                with m.Else():
-                    m.d.comb += led_reg[n].eq(-self.led[n//2])
-            else:
-                with m.If(self.led[n//2] > 0):
-                    m.d.comb += led_reg[n].eq(self.led[n//2])
-                with m.Else():
-                    m.d.comb += led_reg[n].eq(0)
-
-        touch_nsensor = Signal(range(self.N_SENSORS))
-
-        with m.FSM() as fsm:
-
-            #
-            # PCA9557 init
-            #
-
-            cur, _,   ix  = i2c_addr (m, ix, self.PCA9557_ADDR)
-            _,   _,   ix  = i2c_write(m, ix, 0x02)
-            _,   _,   ix  = i2c_write(m, ix, 0x00, last=True)
-            _,   _,   ix  = i2c_wait (m, ix) # set polarity inversion reg
-
-            #
-            # PCA9635 init
-            #
-            _,   _,   ix  = i2c_addr (m, ix, self.PCA9635_ADDR)
-            _,   _,   ix  = i2c_w_arr(m, ix, self.PCA9635_CFG)
-            _,   _,   ix  = i2c_wait (m, ix)
-
-            #
-            # AK4619VN init
-            #
-            _,   _,   ix  = i2c_addr (m, ix, self.AK4619VN_ADDR)
-            _,   _,   ix  = i2c_w_arr(m, ix, self.AK4619VN_CFG)
-            _,   _,   ix  = i2c_wait (m, ix)
-
-            #
-            # BEGIN MAIN LOOP
-            #
-
-            #
-            # PCA9635 update (LED brightnesses)
-            #
-            cur, _,   ix  = i2c_addr (m, ix, self.PCA9635_ADDR)
-            _,   _,   ix  = i2c_write(m, ix, 0x82) # start from first brightness reg
-            for n in range(self.N_LEDS):
-                _,   _,   ix  = i2c_write(m, ix, led_reg[n], last=(n==self.N_LEDS-1))
-            _,   _,   ix  = i2c_wait (m, ix)
-
-            s_loop_begin = cur
-
-            #
-            # CY8CMBR3108 read (Touch scan registers)
-            #
-
-            _,   _,   ix  = i2c_addr (m, ix, self.CY8CMBR3108_ADDR)
-            _,   _,   ix  = i2c_write(m, ix, 0xBA + (touch_nsensor<<1))
-            _,   _,   ix  = i2c_read (m, ix, last=True)
-            _,   _,   ix  = i2c_wait (m, ix)
-
-            # Latch valid reads to dedicated touch register.
-            cur, nxt, ix = state_id(ix)
-            with m.State(cur):
-                m.d.sync += touch_nsensor.eq(touch_nsensor+1)
-                with m.If(~i2c.status.error):
-                    with m.Switch(touch_nsensor):
-                        for n in range(8):
-                            m.d.sync += self.touch[n].eq(i2c.o.payload)
-                    m.d.comb += i2c.o.ready.eq(1)
-                m.next = nxt
-
-            #
-            # PCA9557 read (Jack input port register)
-            #
-            _,   _,   ix  = i2c_addr (m, ix, self.PCA9557_ADDR)
-            _,   _,   ix  = i2c_write(m, ix, 0x00)
-            _,   _,   ix  = i2c_read (m, ix, last=True)
-            _,   nxt, ix  = i2c_wait (m, ix)
-
-            # Latch valid reads to dedicated jack register.
-            with m.State(nxt):
-                with m.If(~i2c.status.error):
-                    m.d.sync += self.jack.eq(i2c.o.payload)
-                    m.d.comb += i2c.o.ready.eq(1)
-                # Go back to LED brightness update
-                m.next = s_loop_begin
-
-        return m
 
 class I2CTests(unittest.TestCase):
 
@@ -334,22 +92,18 @@ class I2CTests(unittest.TestCase):
     def test_i2c_master(self):
 
         m = Module()
-        dut = PmodMaster()
+        dut = eurorack_pmod.I2CMaster(audio_192=False)
         m.submodules += [dut]
+
+        TICKS = 20000
 
         async def test_response(ctx):
             was_busy = False
             data_written = []
             ctx.set(dut.led[0], -10)
             ctx.set(dut.led[1], 10)
-            while True:
+            for _ in range(TICKS):
                 await ctx.tick()
-                """
-                if ctx.get(dut.i2c_stream.status.busy) and not was_busy:
-                    was_busy = True
-                if was_busy and not ctx.get(dut.i2c_stream.status.busy):
-                    break
-                """
                 if ctx.get(dut.i2c_stream.i2c.start):
                     print("i2c.start")
                 if ctx.get(dut.i2c_stream.i2c.write):


### PR DESCRIPTION
- WARN: the TOUCH IC config is no longer flashed by every bitstream. It's now assumed it was already flashed at the factory (or by a sane previous bitstream). This was removed both to save logic and to allow for pop-free bitstream switching (reflashing the touch IC sometimes resets the codec, maybe due to a power dip).
- Split up `i2c.Peripheral` and `i2c.Streamer`, so the transaction-based I2C core can be used more easily by RTL directly.
- Rewrite the old `eurorack-pmod` state machine in Amaranth based on this new interface.
  - This is used for codec, touch init, jack reading, etc
- Resource usage is almost the same as it used to be.
- Crucially, this enables codec muting (pop-free bitstream switching), but is disabled for now.
- Persistent PDN clocking is now enabled on mobo R3+ (required for muting)